### PR TITLE
Various improvements by BejoIjo (initial)

### DIFF
--- a/ComputerPlus/BritishPolicingFunctions.cs
+++ b/ComputerPlus/BritishPolicingFunctions.cs
@@ -1,0 +1,149 @@
+﻿using System;
+using Rage;
+using LSPD_First_Response.Engine.Scripting.Entities;
+using British_Policing_Script;
+using British_Policing_Script.API;
+using ComputerPlus.Extensions;
+using LSPD_First_Response;
+using ComputerPlus.Controllers.Models;
+
+namespace ComputerPlus
+{
+    internal static class BritishPolicingFunctions
+    {
+
+
+        internal static Persona GetBritishPersona(Ped ped)
+        {
+            return Functions.GetBritishPersona(ped);
+        }
+
+        internal static String GetPedPersonaFullName(Persona persona)
+        {
+            return (persona as BritishPersona).FullName;
+        }
+
+        internal static String GetPedPersonaForeName(Persona persona)
+        {
+            return (persona as BritishPersona).Forename;
+        }
+
+        internal static String GetPedPersonaSurName(Persona persona)
+        {
+            return (persona as BritishPersona).Surname;
+        }
+
+        internal static String GetPedPersonaDOBString(Persona persona)
+        {
+            return (persona as BritishPersona).BirthDay.ToLocalTimeString(Extensions.Gwen.TextBoxExtensions.DateOutputPart.DATE);
+        }
+
+        internal static DateTime GetPedPersonaBirthDay(Persona persona)
+        {
+            return (persona as BritishPersona).BirthDay;
+        }
+
+        internal static int GetPedPersonaTimesStopped(Persona persona)
+        {
+            return (persona as BritishPersona).TimesStopped;
+        }
+
+        internal static Gender GetPedPersonaGender(Persona persona)
+        {
+            return (persona as BritishPersona).Gender;
+        }
+
+        internal static bool GetPedPersonaIsWanted(Persona persona)
+        {
+            return (persona as BritishPersona).Wanted;
+        }
+
+        internal static bool GetPedPersonaIsAgent(Persona persona)
+        {
+            return (persona as BritishPersona).IsAgent;
+        }
+
+        internal static bool GetPedPersonaIsCop(Persona persona)
+        {
+            return (persona as BritishPersona).IsCop;
+        }
+
+        internal static String GetPedPersonaWantedReason(Persona persona)
+        {
+            return (persona as BritishPersona).WantedReason;
+        }
+
+        internal static String GetVehicleLicensePlate(System.Object rawPersona)
+        {
+            return (rawPersona as VehicleRecords).LicencePlate;
+        }
+
+        internal static bool IsVehicleRegistered(System.Object rawPersona)
+        {
+            return (rawPersona as VehicleRecords).IsTaxed;
+        }
+
+        internal static bool IsVehicleInsured(System.Object rawPersona)
+        {
+            return (rawPersona as VehicleRecords).Insured;
+        }
+
+        internal static bool DoesVehicleHaveMOT(System.Object rawPersona)
+        {
+            return (rawPersona as VehicleRecords).HasMOT;
+        }
+
+        internal static bool DoesVehicleHaveSORN(System.Object rawPersona)
+        {
+            return (rawPersona as VehicleRecords).HasSORN;
+        }
+
+        internal static bool IsPedInsuredToDriveVehicle(System.Object rawPedPersona, System.Object rawVehiclePersona)
+        {
+            var pedPersona = rawPedPersona as BritishPersona;
+            var vehiclePersona = rawVehiclePersona as VehicleRecords;
+            return pedPersona.IsInsuredToDriveVehicle(vehiclePersona);
+        }
+
+        internal static bool IsLicenseValid(Persona pedPersona)
+        {
+            var persona = pedPersona as BritishPersona;
+            switch (persona.LicenceStatus)
+            {
+                case BritishPersona.LicenceStatuses.Disqualified:
+                case BritishPersona.LicenceStatuses.Expired:
+                case BritishPersona.LicenceStatuses.Revoked: return false;
+                default: return true;
+            }
+        }
+
+        internal static String GetLicenseStateString(Persona pedPersona)
+        {
+            var persona = pedPersona as BritishPersona;
+            switch (persona.LicenceStatus)
+            {
+                case BritishPersona.LicenceStatuses.Disqualified: return "Disqualified";
+                case BritishPersona.LicenceStatuses.Expired: return "Expired";
+                case BritishPersona.LicenceStatuses.Revoked: return "Revoked";
+                default: return "Valid";
+            }
+        }
+
+        internal static VehiclePersona CreateVehiclePersona(Vehicle veh)
+        {
+            VehicleRecords records = Functions.GetVehicleRecords(veh);
+
+            VehiclePersona vehiclePersona = new VehiclePersona();
+            vehiclePersona.HasInsurance = records.Insured;
+            vehiclePersona.IsRegistered = null;
+            vehiclePersona.Color = records.CarColour;
+            vehiclePersona.Alert = new System.Text.RegularExpressions.Regex(@"~\w~").Replace(records.DetermineFlags(), String.Empty);
+            vehiclePersona.HasValidEmissions = records.HasMOT;
+            vehiclePersona.IsOffroadOnly = records.HasSORN;
+            vehiclePersona.IsTaxed = records.IsTaxed;
+            vehiclePersona.RawPersona = records;
+
+            return vehiclePersona;
+        }
+    }
+}

--- a/ComputerPlus/ComputerPlus.csproj
+++ b/ComputerPlus/ComputerPlus.csproj
@@ -23,6 +23,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -136,6 +137,7 @@
     <Compile Include="API\Functions.cs" />
     <Compile Include="API\ICalloutData.cs" />
     <Compile Include="API\MDTAPI.cs" />
+    <Compile Include="BritishPolicingFunctions.cs" />
     <Compile Include="Controllers\ComputerReportsController.cs" />
     <Compile Include="Controllers\Models\ALRP_Arguments.cs" />
     <Compile Include="Controllers\Models\ComputerPlusEntity.cs" />
@@ -394,9 +396,9 @@ xcopy /Y "$(ProjectDir)Resources\backgrounds\*.jpg" "$(TargetDir)Packaged\Plugin
 xcopy /Y "$(ProjectDir)Resources\ComputerPlus.ini" "$(TargetDir)Packaged\Plugins\LSPDFR\"
 
 
-xcopy /Y "$(TargetDir)ComputerPlus.dll" "F:\Rockstar Games\Plugins\LSPDFR"
+xcopy /Y "$(TargetDir)ComputerPlus.dll" "D:\Steam\steamapps\common\Grand Theft Auto V\plugins\LSPDFR"
 
-xcopy /Y "$(TargetDir)ComputerPlus.pdb" "F:\Rockstar Games\Plugins\LSPDFR"</PostBuildEvent>
+xcopy /Y "$(TargetDir)ComputerPlus.pdb" "D:\Steam\steamapps\common\Grand Theft Auto V\plugins\LSPDFR"</PostBuildEvent>
   </PropertyGroup>
   <PropertyGroup>
     <PreBuildEvent>

--- a/ComputerPlus/Controllers/ComputerPedController.cs
+++ b/ComputerPlus/Controllers/ComputerPedController.cs
@@ -36,7 +36,6 @@ namespace ComputerPlus.Interfaces.ComputerPedDB
             }
         }
 
-
         internal List<Ped> PedsCurrentlyStoppedByPlayer
         {
             get
@@ -62,14 +61,17 @@ namespace ComputerPlus.Interfaces.ComputerPedDB
             peds.RemoveAll(p => !p || !p.Exists() || (p != null && !p.IsValid()));
             peds.OrderBy(p => p.DistanceTo(Game.LocalPlayer.Character.Position));
             var ped = peds.Where(p => p && Functions.GetPersonaForPed(p).FullName.ToLower().Equals(name)).FirstOrDefault();
-            if (ped == null) return null;
-            return ComputerPlusEntity.CreateFrom(ped);
+            return LookupPersona(ped);
         }
        
         internal ComputerPlusEntity LookupPersona(Ped ped)
         {
             if (ped == null || (ped != null && !ped.Exists())) return null;
-            var entity = ComputerPlusEntity.CreateFrom(ped);
+            return insertEntityToRecentSearches(ComputerPlusEntity.CreateFrom(ped));
+        }
+
+        internal static ComputerPlusEntity insertEntityToRecentSearches(ComputerPlusEntity entity)
+        {
             bool found = false;
             foreach (var ent in RecentSearches)
             {
@@ -100,7 +102,13 @@ namespace ComputerPlus.Interfaces.ComputerPedDB
             int index = Globals.Random.Next(0, Globals.WantedReasons.Count);
             return Globals.WantedReasons[index];
         }
-        
+
+        internal static CitationDefinition GetRandomCitation()
+        {
+            int index = Globals.Random.Next(0, Globals.CitationList.Count);
+            return Globals.CitationList[index];
+        }
+
         internal static void ShowPedSearch()
         {
             Globals.Navigation.Push(new ComputerPedSearch());

--- a/ComputerPlus/Controllers/Models/ComputerPlusEntity.cs
+++ b/ComputerPlus/Controllers/Models/ComputerPlusEntity.cs
@@ -62,7 +62,7 @@ namespace ComputerPlus.Controllers.Models
                 if (!CreatedWith.HasFlag(EntityTypes.Ped) || !Ped) return String.Empty;
                 switch(PersonaType)
                 {
-                    case PersonaTypes.BPS: return (PedPersona as British_Policing_Script.BritishPersona).FullName;
+                    case PersonaTypes.BPS: return BritishPolicingFunctions.GetPedPersonaFullName(PedPersona);
                     default: return PedPersona.FullName;
                 }
             }
@@ -75,7 +75,7 @@ namespace ComputerPlus.Controllers.Models
                 if (!CreatedWith.HasFlag(EntityTypes.Ped) || !Ped) return String.Empty;
                 switch (PersonaType)
                 {
-                    case PersonaTypes.BPS: return (PedPersona as British_Policing_Script.BritishPersona).Forename;
+                    case PersonaTypes.BPS: return BritishPolicingFunctions.GetPedPersonaForeName(PedPersona);
                     default: return PedPersona.Forename;
                 }
             }
@@ -88,7 +88,7 @@ namespace ComputerPlus.Controllers.Models
                 if (!CreatedWith.HasFlag(EntityTypes.Ped) || !Ped) return String.Empty;
                 switch (PersonaType)
                 {
-                    case PersonaTypes.BPS: return (PedPersona as British_Policing_Script.BritishPersona).Surname;
+                    case PersonaTypes.BPS: return BritishPolicingFunctions.GetPedPersonaSurName(PedPersona); ;
                     default: return PedPersona.Surname;
                 }
             }
@@ -110,7 +110,7 @@ namespace ComputerPlus.Controllers.Models
                 if (!CreatedWith.HasFlag(EntityTypes.Ped) || !Vehicle) return String.Empty;
                 switch (PersonaType)
                 {
-                    case PersonaTypes.BPS: return (VehiclePersona.RawPersona as British_Policing_Script.VehicleRecords).LicencePlate;
+                    case PersonaTypes.BPS: return BritishPolicingFunctions.GetVehicleLicensePlate(VehiclePersona.RawPersona);
                     default: return Vehicle.LicensePlate;
                 }
             }
@@ -123,7 +123,7 @@ namespace ComputerPlus.Controllers.Models
                 if (!CreatedWith.HasFlag(EntityTypes.Ped) || !Ped) return String.Empty;
                 switch (PersonaType)
                 {
-                    case PersonaTypes.BPS: return (PedPersona as British_Policing_Script.BritishPersona).BirthDay.ToLocalTimeString(Extensions.Gwen.TextBoxExtensions.DateOutputPart.DATE);
+                    case PersonaTypes.BPS: return BritishPolicingFunctions.GetPedPersonaDOBString(PedPersona);
                     default: return PedPersona.BirthDay.ToLocalTimeString(Extensions.Gwen.TextBoxExtensions.DateOutputPart.DATE);
                 }
             }
@@ -138,10 +138,9 @@ namespace ComputerPlus.Controllers.Models
                 DateTime birthDate;
                 switch (PersonaType)
                 {
-                    case PersonaTypes.BPS: birthDate = (PedPersona as British_Policing_Script.BritishPersona).BirthDay; break;
+                    case PersonaTypes.BPS: birthDate = BritishPolicingFunctions.GetPedPersonaBirthDay(PedPersona); break;
                     default: birthDate = PedPersona.BirthDay; break;
                 }
-
                 return  (int)((DateTime.Today - birthDate).Days / 365.25m);
             }
         }
@@ -161,7 +160,7 @@ namespace ComputerPlus.Controllers.Models
                 if (!CreatedWith.HasFlag(EntityTypes.Ped) || !Ped) return 0;
                 switch (PersonaType)
                 {
-                    case PersonaTypes.BPS: return (PedPersona as British_Policing_Script.BritishPersona).TimesStopped;
+                    case PersonaTypes.BPS: return BritishPolicingFunctions.GetPedPersonaTimesStopped(PedPersona);
                     default: return PedPersona.TimesStopped;
                 }
             }
@@ -174,7 +173,7 @@ namespace ComputerPlus.Controllers.Models
                 if (!CreatedWith.HasFlag(EntityTypes.Ped) || !Ped) return LSPD_First_Response.Gender.Random;
                 switch (PersonaType)
                 {
-                    case PersonaTypes.BPS: return (PedPersona as British_Policing_Script.BritishPersona).Gender;
+                    case PersonaTypes.BPS: return BritishPolicingFunctions.GetPedPersonaGender(PedPersona);
                     default: return PedPersona.Gender;
                 }
             }
@@ -203,7 +202,7 @@ namespace ComputerPlus.Controllers.Models
                 if (!CreatedWith.HasFlag(EntityTypes.Ped) || !Ped) return false;
                 switch (PersonaType)
                 {
-                    case PersonaTypes.BPS: return (PedPersona as British_Policing_Script.BritishPersona).Wanted;
+                    case PersonaTypes.BPS: return BritishPolicingFunctions.GetPedPersonaIsWanted(PedPersona);
                     default: return PedPersona.Wanted;
                 }
             }
@@ -216,8 +215,8 @@ namespace ComputerPlus.Controllers.Models
                 if (!CreatedWith.HasFlag(EntityTypes.Ped) || !Ped) return String.Empty;
                 switch (PersonaType)
                 {
-                    case PersonaTypes.BPS: return (PedPersona as British_Policing_Script.BritishPersona).WantedReason;
-                    default: return String.Empty; //@TODO random wanted reason generator will go here
+                    case PersonaTypes.BPS: return BritishPolicingFunctions.GetPedPersonaWantedReason(PedPersona);
+                    default: return Ped.GetWantedReason();
                 }
             }
         }
@@ -227,16 +226,9 @@ namespace ComputerPlus.Controllers.Models
             get
             {              
                   
-                if (ComputerPlusEntity.PersonaType == PersonaTypes.BPS)
+                if (PersonaType == PersonaTypes.BPS)
                 {
-                    var persona = PedPersona as British_Policing_Script.BritishPersona;
-                    switch (persona.LicenceStatus)
-                    {
-                        case British_Policing_Script.BritishPersona.LicenceStatuses.Disqualified:
-                        case British_Policing_Script.BritishPersona.LicenceStatuses.Expired:
-                        case British_Policing_Script.BritishPersona.LicenceStatuses.Revoked: return false;
-                        default: return true;
-                    }
+                    return BritishPolicingFunctions.IsLicenseValid(PedPersona);
                 }
                 else {
                     switch (PedPersona.LicenseState)
@@ -255,14 +247,7 @@ namespace ComputerPlus.Controllers.Models
             {
                 if (PersonaType == PersonaTypes.BPS)
                 {
-                    var persona = PedPersona as British_Policing_Script.BritishPersona;
-                    switch (persona.LicenceStatus)
-                    {
-                        case British_Policing_Script.BritishPersona.LicenceStatuses.Disqualified: return "Disqualified";
-                        case British_Policing_Script.BritishPersona.LicenceStatuses.Expired: return "Expired";
-                        case British_Policing_Script.BritishPersona.LicenceStatuses.Revoked: return "Revoked";
-                        default: return "Valid";
-                    }
+                    return BritishPolicingFunctions.GetLicenseStateString(PedPersona);
                 }
                 else
                 {
@@ -285,7 +270,7 @@ namespace ComputerPlus.Controllers.Models
                 if (!CreatedWith.HasFlag(EntityTypes.Ped) || !Ped) return false;
                 switch (PersonaType)
                 {
-                    case PersonaTypes.BPS: return (PedPersona as British_Policing_Script.BritishPersona).IsAgent;
+                    case PersonaTypes.BPS: return BritishPolicingFunctions.GetPedPersonaIsAgent(PedPersona);
                     default: return PedPersona.IsAgent;
                 }
             }
@@ -298,7 +283,7 @@ namespace ComputerPlus.Controllers.Models
                 if (!CreatedWith.HasFlag(EntityTypes.Ped) || !Ped) return false;
                 switch (PersonaType)
                 {
-                    case PersonaTypes.BPS: return (PedPersona as British_Policing_Script.BritishPersona).IsCop;
+                    case PersonaTypes.BPS: return BritishPolicingFunctions.GetPedPersonaIsCop(PedPersona);
                     default: return PedPersona.IsCop;
                 }
             }
@@ -328,7 +313,7 @@ namespace ComputerPlus.Controllers.Models
                 if (!CreatedWith.HasFlag(EntityTypes.Vehicle) || !Vehicle) return true;
                 switch (PersonaType)
                 {
-                    case PersonaTypes.BPS: return (VehiclePersona.RawPersona as British_Policing_Script.VehicleRecords).IsTaxed;
+                    case PersonaTypes.BPS: return BritishPolicingFunctions.IsVehicleRegistered(VehiclePersona.RawPersona);
                     default: return VehiclePersona.IsRegistered.HasValue ? VehiclePersona.IsRegistered.Value : true;
                 }
             }
@@ -458,7 +443,7 @@ namespace ComputerPlus.Controllers.Models
         {
             if (PersonaType == PersonaTypes.BPS)
             {
-                return British_Policing_Script.API.Functions.GetBritishPersona(ped);
+                return BritishPolicingFunctions.GetBritishPersona(ped);
             }
             else
             {
@@ -470,8 +455,7 @@ namespace ComputerPlus.Controllers.Models
         {
             if (PersonaType == PersonaTypes.BPS)
             {
-                var records = British_Policing_Script.API.Functions.GetVehicleRecords(vehicle);
-                return new VehiclePersona(records);
+                return BritishPolicingFunctions.CreateVehiclePersona(vehicle);
             }
             else
             {
@@ -480,6 +464,11 @@ namespace ComputerPlus.Controllers.Models
                 {
                     vehiclePersona.HasInsurance = TrafficPolicerFunction.GetVehicleInsuranceStatus(vehicle) == EVehicleStatus.Valid ? true : false;
                     vehiclePersona.IsRegistered = TrafficPolicerFunction.GetVehicleRegistrationStatus(vehicle) == EVehicleStatus.Valid ? true : false;
+                }
+                else
+                {
+                    vehiclePersona.HasInsurance = false;
+                    vehiclePersona.IsRegistered = false;
                 }
                 return vehiclePersona;
             }

--- a/ComputerPlus/Controllers/Models/ComputerPlusEntity.cs
+++ b/ComputerPlus/Controllers/Models/ComputerPlusEntity.cs
@@ -124,7 +124,7 @@ namespace ComputerPlus.Controllers.Models
                 switch (PersonaType)
                 {
                     case PersonaTypes.BPS: return BritishPolicingFunctions.GetPedPersonaDOBString(PedPersona);
-                    default: return PedPersona.BirthDay.ToLocalTimeString(Extensions.Gwen.TextBoxExtensions.DateOutputPart.DATE);
+                    default: return PedPersona.BirthDay.ToDateTimeString(Extensions.Gwen.TextBoxExtensions.DateOutputPart.DATE);
                 }
             }
 

--- a/ComputerPlus/Controllers/Models/VehiclePersona.cs
+++ b/ComputerPlus/Controllers/Models/VehiclePersona.cs
@@ -28,19 +28,6 @@ namespace ComputerPlus.Controllers.Models
             HasValidEmissions = null;
             IsTaxed = null;
             RawPersona = rawPersona;
-        }      
-        
-        public VehiclePersona(British_Policing_Script.VehicleRecords records)
-        {
-            IsRegistered = null;
-            HasInsurance = records.Insured;
-            Color = records.CarColour;
-
-            Alert = new System.Text.RegularExpressions.Regex(@"~\w~").Replace(records.DetermineFlags(), String.Empty);
-            HasValidEmissions = records.HasMOT;
-            IsOffroadOnly = records.HasSORN;
-            IsTaxed = records.IsTaxed;
-            RawPersona = records;
         }
     }
 }

--- a/ComputerPlus/DB/Models/IDBModel.cs
+++ b/ComputerPlus/DB/Models/IDBModel.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace ComputerPlus.DB.Models
 {

--- a/ComputerPlus/Extensions/DateTimeExtension.cs
+++ b/ComputerPlus/Extensions/DateTimeExtension.cs
@@ -1,8 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using static ComputerPlus.Extensions.Gwen.TextBoxExtensions;
 
 namespace ComputerPlus.Extensions
@@ -11,7 +7,13 @@ namespace ComputerPlus.Extensions
     {
         internal static String ToLocalTimeString(this DateTime date, DateOutputPart output = DateOutputPart.ALL)
         {
-            var local = date.ToLocalTime();
+            return date.ToDateTimeString(output, true);
+        }
+
+        internal static String ToDateTimeString(this DateTime date, DateOutputPart output = DateOutputPart.ALL, bool convertToLocal = false)
+        {
+            var local = date;
+            if (convertToLocal) local = date.ToLocalTime();
             switch (output)
             {
                 case DateOutputPart.DATE: return local.ToShortDateString();

--- a/ComputerPlus/Extensions/Rage/PedExtensions.cs
+++ b/ComputerPlus/Extensions/Rage/PedExtensions.cs
@@ -15,5 +15,19 @@ namespace ComputerPlus.Extensions.Rage
             if (ped.Metadata.HomeAddress == null) ped.Metadata.HomeAddress = ComputerPedController.GetRandomStreetAddress();
             return ped.Metadata.HomeAddress;
         }
+
+        internal static String GetWantedReason(this Ped ped)
+        {
+            if (ped.Metadata.WantedReason == null) ped.Metadata.WantedReason = ComputerPedController.GetRandomWantedReason();
+            return ped.Metadata.WantedReason;
+        }
+
+        internal static String GetDrivingLicenseExpirationDuration(this Ped ped)
+        {
+            if (ped.Metadata.DrivingLicenseExpirationDuration == null) {
+                ped.Metadata.DrivingLicenseExpirationDuration = Globals.Random.Next(2, 360).ToString();
+            }
+            return ped.Metadata.DrivingLicenseExpirationDuration;
+        }
     }
 }

--- a/ComputerPlus/Extensions/Rage/PedScenarios.cs
+++ b/ComputerPlus/Extensions/Rage/PedScenarios.cs
@@ -1,0 +1,184 @@
+using Rage;
+using Rage.Native;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace ComputerPlus.Extensions.Rage
+{
+    /**
+    * Credit to PNWParksFan
+    * https://bitbucket.org/snippets/gtaparks/y4a8M
+    */
+    static class PedScenarios
+    {
+#pragma warning disable 1591
+        public static string WORLD_HUMAN_AA_COFFEE { get { return "WORLD_HUMAN_AA_COFFEE"; } }
+        public static string WORLD_HUMAN_AA_SMOKE { get { return "WORLD_HUMAN_AA_SMOKE"; } }
+        public static string WORLD_HUMAN_BINOCULARS { get { return "WORLD_HUMAN_BINOCULARS"; } }
+        public static string WORLD_HUMAN_BUM_FREEWAY { get { return "WORLD_HUMAN_BUM_FREEWAY"; } }
+        public static string WORLD_HUMAN_BUM_SLUMPED { get { return "WORLD_HUMAN_BUM_SLUMPED"; } }
+        public static string WORLD_HUMAN_BUM_STANDING { get { return "WORLD_HUMAN_BUM_STANDING"; } }
+        public static string WORLD_HUMAN_BUM_WASH { get { return "WORLD_HUMAN_BUM_WASH"; } }
+        public static string WORLD_HUMAN_CAR_PARK_ATTENDANT { get { return "WORLD_HUMAN_CAR_PARK_ATTENDANT"; } }
+        public static string WORLD_HUMAN_CHEERING { get { return "WORLD_HUMAN_CHEERING"; } }
+        public static string WORLD_HUMAN_CLIPBOARD { get { return "WORLD_HUMAN_CLIPBOARD"; } }
+        public static string WORLD_HUMAN_CONST_DRILL { get { return "WORLD_HUMAN_CONST_DRILL"; } }
+        public static string WORLD_HUMAN_COP_IDLES { get { return "WORLD_HUMAN_COP_IDLES"; } }
+        public static string WORLD_HUMAN_DRINKING { get { return "WORLD_HUMAN_DRINKING"; } }
+        public static string WORLD_HUMAN_DRUG_DEALER { get { return "WORLD_HUMAN_DRUG_DEALER"; } }
+        public static string WORLD_HUMAN_DRUG_DEALER_HARD { get { return "WORLD_HUMAN_DRUG_DEALER_HARD"; } }
+        public static string WORLD_HUMAN_MOBILE_FILM_SHOCKING { get { return "WORLD_HUMAN_MOBILE_FILM_SHOCKING"; } }
+        public static string WORLD_HUMAN_GARDENER_LEAF_BLOWER { get { return "WORLD_HUMAN_GARDENER_LEAF_BLOWER"; } }
+        public static string WORLD_HUMAN_GARDENER_PLANT { get { return "WORLD_HUMAN_GARDENER_PLANT"; } }
+        public static string WORLD_HUMAN_GOLF_PLAYER { get { return "WORLD_HUMAN_GOLF_PLAYER"; } }
+        public static string WORLD_HUMAN_GUARD_PATROL { get { return "WORLD_HUMAN_GUARD_PATROL"; } }
+        public static string WORLD_HUMAN_GUARD_STAND { get { return "WORLD_HUMAN_GUARD_STAND"; } }
+        public static string WORLD_HUMAN_GUARD_STAND_ARMY { get { return "WORLD_HUMAN_GUARD_STAND_ARMY"; } }
+        public static string WORLD_HUMAN_HAMMERING { get { return "WORLD_HUMAN_HAMMERING"; } }
+        public static string WORLD_HUMAN_HANG_OUT_STREET { get { return "WORLD_HUMAN_HANG_OUT_STREET"; } }
+        public static string WORLD_HUMAN_HIKER_STANDING { get { return "WORLD_HUMAN_HIKER_STANDING"; } }
+        public static string WORLD_HUMAN_HUMAN_STATUE { get { return "WORLD_HUMAN_HUMAN_STATUE"; } }
+        public static string WORLD_HUMAN_JANITOR { get { return "WORLD_HUMAN_JANITOR"; } }
+        public static string WORLD_HUMAN_JOG_STANDING { get { return "WORLD_HUMAN_JOG_STANDING"; } }
+        public static string WORLD_HUMAN_LEANING { get { return "WORLD_HUMAN_LEANING"; } }
+        public static string WORLD_HUMAN_MAID_CLEAN { get { return "WORLD_HUMAN_MAID_CLEAN"; } }
+        public static string WORLD_HUMAN_MUSCLE_FLEX { get { return "WORLD_HUMAN_MUSCLE_FLEX"; } }
+        public static string WORLD_HUMAN_MUSCLE_FREE_WEIGHTS { get { return "WORLD_HUMAN_MUSCLE_FREE_WEIGHTS"; } }
+        public static string WORLD_HUMAN_MUSICIAN { get { return "WORLD_HUMAN_MUSICIAN"; } }
+        public static string WORLD_HUMAN_PAPARAZZI { get { return "WORLD_HUMAN_PAPARAZZI"; } }
+        public static string WORLD_HUMAN_PARTYING { get { return "WORLD_HUMAN_PARTYING"; } }
+        public static string WORLD_HUMAN_PICNIC { get { return "WORLD_HUMAN_PICNIC"; } }
+        public static string WORLD_HUMAN_PROSTITUTE_HIGH_CLASS { get { return "WORLD_HUMAN_PROSTITUTE_HIGH_CLASS"; } }
+        public static string WORLD_HUMAN_PROSTITUTE_LOW_CLASS { get { return "WORLD_HUMAN_PROSTITUTE_LOW_CLASS"; } }
+        public static string WORLD_HUMAN_PUSH_UPS { get { return "WORLD_HUMAN_PUSH_UPS"; } }
+        public static string WORLD_HUMAN_SEAT_LEDGE { get { return "WORLD_HUMAN_SEAT_LEDGE"; } }
+        public static string WORLD_HUMAN_SEAT_LEDGE_EATING { get { return "WORLD_HUMAN_SEAT_LEDGE_EATING"; } }
+        public static string WORLD_HUMAN_SEAT_STEPS { get { return "WORLD_HUMAN_SEAT_STEPS"; } }
+        public static string WORLD_HUMAN_SEAT_WALL { get { return "WORLD_HUMAN_SEAT_WALL"; } }
+        public static string WORLD_HUMAN_SEAT_WALL_EATING { get { return "WORLD_HUMAN_SEAT_WALL_EATING"; } }
+        public static string WORLD_HUMAN_SEAT_WALL_TABLET { get { return "WORLD_HUMAN_SEAT_WALL_TABLET"; } }
+        public static string WORLD_HUMAN_SECURITY_SHINE_TORCH { get { return "WORLD_HUMAN_SECURITY_SHINE_TORCH"; } }
+        public static string WORLD_HUMAN_SIT_UPS { get { return "WORLD_HUMAN_SIT_UPS"; } }
+        public static string WORLD_HUMAN_SMOKING { get { return "WORLD_HUMAN_SMOKING"; } }
+        public static string WORLD_HUMAN_SMOKING_POT { get { return "WORLD_HUMAN_SMOKING_POT"; } }
+        public static string WORLD_HUMAN_STAND_FIRE { get { return "WORLD_HUMAN_STAND_FIRE"; } }
+        public static string WORLD_HUMAN_STAND_FISHING { get { return "WORLD_HUMAN_STAND_FISHING"; } }
+        public static string WORLD_HUMAN_STAND_IMPATIENT { get { return "WORLD_HUMAN_STAND_IMPATIENT"; } }
+        public static string WORLD_HUMAN_STAND_IMPATIENT_UPRIGHT { get { return "WORLD_HUMAN_STAND_IMPATIENT_UPRIGHT"; } }
+        public static string WORLD_HUMAN_STAND_MOBILE { get { return "WORLD_HUMAN_STAND_MOBILE"; } }
+        public static string WORLD_HUMAN_STAND_MOBILE_UPRIGHT { get { return "WORLD_HUMAN_STAND_MOBILE_UPRIGHT"; } }
+        public static string WORLD_HUMAN_STRIP_WATCH_STAND { get { return "WORLD_HUMAN_STRIP_WATCH_STAND"; } }
+        public static string WORLD_HUMAN_STUPOR { get { return "WORLD_HUMAN_STUPOR"; } }
+        public static string WORLD_HUMAN_SUNBATHE { get { return "WORLD_HUMAN_SUNBATHE"; } }
+        public static string WORLD_HUMAN_SUNBATHE_BACK { get { return "WORLD_HUMAN_SUNBATHE_BACK"; } }
+        public static string WORLD_HUMAN_SUPERHERO { get { return "WORLD_HUMAN_SUPERHERO"; } }
+        public static string WORLD_HUMAN_SWIMMING { get { return "WORLD_HUMAN_SWIMMING"; } }
+        public static string WORLD_HUMAN_TENNIS_PLAYER { get { return "WORLD_HUMAN_TENNIS_PLAYER"; } }
+        public static string WORLD_HUMAN_TOURIST_MAP { get { return "WORLD_HUMAN_TOURIST_MAP"; } }
+        public static string WORLD_HUMAN_TOURIST_MOBILE { get { return "WORLD_HUMAN_TOURIST_MOBILE"; } }
+        public static string WORLD_HUMAN_VEHICLE_MECHANIC { get { return "WORLD_HUMAN_VEHICLE_MECHANIC"; } }
+        public static string WORLD_HUMAN_WELDING { get { return "WORLD_HUMAN_WELDING"; } }
+        public static string WORLD_HUMAN_WINDOW_SHOP_BROWSE { get { return "WORLD_HUMAN_WINDOW_SHOP_BROWSE"; } }
+        public static string WORLD_HUMAN_YOGA { get { return "WORLD_HUMAN_YOGA"; } }
+        public static string WORLD_BOAR_GRAZING { get { return "WORLD_BOAR_GRAZING"; } }
+        public static string WORLD_CAT_SLEEPING_GROUND { get { return "WORLD_CAT_SLEEPING_GROUND"; } }
+        public static string WORLD_CAT_SLEEPING_LEDGE { get { return "WORLD_CAT_SLEEPING_LEDGE"; } }
+        public static string WORLD_COW_GRAZING { get { return "WORLD_COW_GRAZING"; } }
+        public static string WORLD_COYOTE_HOWL { get { return "WORLD_COYOTE_HOWL"; } }
+        public static string WORLD_COYOTE_REST { get { return "WORLD_COYOTE_REST"; } }
+        public static string WORLD_COYOTE_WANDER { get { return "WORLD_COYOTE_WANDER"; } }
+        public static string WORLD_CHICKENHAWK_FEEDING { get { return "WORLD_CHICKENHAWK_FEEDING"; } }
+        public static string WORLD_CHICKENHAWK_STANDING { get { return "WORLD_CHICKENHAWK_STANDING"; } }
+        public static string WORLD_CORMORANT_STANDING { get { return "WORLD_CORMORANT_STANDING"; } }
+        public static string WORLD_CROW_FEEDING { get { return "WORLD_CROW_FEEDING"; } }
+        public static string WORLD_CROW_STANDING { get { return "WORLD_CROW_STANDING"; } }
+        public static string WORLD_DEER_GRAZING { get { return "WORLD_DEER_GRAZING"; } }
+        public static string WORLD_DOG_BARKING_ROTTWEILER { get { return "WORLD_DOG_BARKING_ROTTWEILER"; } }
+        public static string WORLD_DOG_BARKING_RETRIEVER { get { return "WORLD_DOG_BARKING_RETRIEVER"; } }
+        public static string WORLD_DOG_BARKING_SHEPHERD { get { return "WORLD_DOG_BARKING_SHEPHERD"; } }
+        public static string WORLD_DOG_SITTING_ROTTWEILER { get { return "WORLD_DOG_SITTING_ROTTWEILER"; } }
+        public static string WORLD_DOG_SITTING_RETRIEVER { get { return "WORLD_DOG_SITTING_RETRIEVER"; } }
+        public static string WORLD_DOG_SITTING_SHEPHERD { get { return "WORLD_DOG_SITTING_SHEPHERD"; } }
+        public static string WORLD_DOG_BARKING_SMALL { get { return "WORLD_DOG_BARKING_SMALL"; } }
+        public static string WORLD_DOG_SITTING_SMALL { get { return "WORLD_DOG_SITTING_SMALL"; } }
+        public static string WORLD_FISH_IDLE { get { return "WORLD_FISH_IDLE"; } }
+        public static string WORLD_GULL_FEEDING { get { return "WORLD_GULL_FEEDING"; } }
+        public static string WORLD_GULL_STANDING { get { return "WORLD_GULL_STANDING"; } }
+        public static string WORLD_HEN_PECKING { get { return "WORLD_HEN_PECKING"; } }
+        public static string WORLD_HEN_STANDING { get { return "WORLD_HEN_STANDING"; } }
+        public static string WORLD_MOUNTAIN_LION_REST { get { return "WORLD_MOUNTAIN_LION_REST"; } }
+        public static string WORLD_MOUNTAIN_LION_WANDER { get { return "WORLD_MOUNTAIN_LION_WANDER"; } }
+        public static string WORLD_PIG_GRAZING { get { return "WORLD_PIG_GRAZING"; } }
+        public static string WORLD_PIGEON_FEEDING { get { return "WORLD_PIGEON_FEEDING"; } }
+        public static string WORLD_PIGEON_STANDING { get { return "WORLD_PIGEON_STANDING"; } }
+        public static string WORLD_RABBIT_EATING { get { return "WORLD_RABBIT_EATING"; } }
+        public static string WORLD_RATS_EATING { get { return "WORLD_RATS_EATING"; } }
+        public static string WORLD_SHARK_SWIM { get { return "WORLD_SHARK_SWIM"; } }
+        public static string PROP_BIRD_IN_TREE { get { return "PROP_BIRD_IN_TREE"; } }
+        public static string PROP_BIRD_TELEGRAPH_POLE { get { return "PROP_BIRD_TELEGRAPH_POLE"; } }
+        public static string PROP_HUMAN_ATM { get { return "PROP_HUMAN_ATM"; } }
+        public static string PROP_HUMAN_BBQ { get { return "PROP_HUMAN_BBQ"; } }
+        public static string PROP_HUMAN_BUM_BIN { get { return "PROP_HUMAN_BUM_BIN"; } }
+        public static string PROP_HUMAN_BUM_SHOPPING_CART { get { return "PROP_HUMAN_BUM_SHOPPING_CART"; } }
+        public static string PROP_HUMAN_MUSCLE_CHIN_UPS { get { return "PROP_HUMAN_MUSCLE_CHIN_UPS"; } }
+        public static string PROP_HUMAN_MUSCLE_CHIN_UPS_ARMY { get { return "PROP_HUMAN_MUSCLE_CHIN_UPS_ARMY"; } }
+        public static string PROP_HUMAN_MUSCLE_CHIN_UPS_PRISON { get { return "PROP_HUMAN_MUSCLE_CHIN_UPS_PRISON"; } }
+        public static string PROP_HUMAN_PARKING_METER { get { return "PROP_HUMAN_PARKING_METER"; } }
+        public static string PROP_HUMAN_SEAT_ARMCHAIR { get { return "PROP_HUMAN_SEAT_ARMCHAIR"; } }
+        public static string PROP_HUMAN_SEAT_BAR { get { return "PROP_HUMAN_SEAT_BAR"; } }
+        public static string PROP_HUMAN_SEAT_BENCH { get { return "PROP_HUMAN_SEAT_BENCH"; } }
+        public static string PROP_HUMAN_SEAT_BENCH_DRINK { get { return "PROP_HUMAN_SEAT_BENCH_DRINK"; } }
+        public static string PROP_HUMAN_SEAT_BENCH_DRINK_BEER { get { return "PROP_HUMAN_SEAT_BENCH_DRINK_BEER"; } }
+        public static string PROP_HUMAN_SEAT_BENCH_FOOD { get { return "PROP_HUMAN_SEAT_BENCH_FOOD"; } }
+        public static string PROP_HUMAN_SEAT_BUS_STOP_WAIT { get { return "PROP_HUMAN_SEAT_BUS_STOP_WAIT"; } }
+        public static string PROP_HUMAN_SEAT_CHAIR { get { return "PROP_HUMAN_SEAT_CHAIR"; } }
+        public static string PROP_HUMAN_SEAT_CHAIR_DRINK { get { return "PROP_HUMAN_SEAT_CHAIR_DRINK"; } }
+        public static string PROP_HUMAN_SEAT_CHAIR_DRINK_BEER { get { return "PROP_HUMAN_SEAT_CHAIR_DRINK_BEER"; } }
+        public static string PROP_HUMAN_SEAT_CHAIR_FOOD { get { return "PROP_HUMAN_SEAT_CHAIR_FOOD"; } }
+        public static string PROP_HUMAN_SEAT_CHAIR_UPRIGHT { get { return "PROP_HUMAN_SEAT_CHAIR_UPRIGHT"; } }
+        public static string PROP_HUMAN_SEAT_CHAIR_MP_PLAYER { get { return "PROP_HUMAN_SEAT_CHAIR_MP_PLAYER"; } }
+        public static string PROP_HUMAN_SEAT_COMPUTER { get { return "PROP_HUMAN_SEAT_COMPUTER"; } }
+        public static string PROP_HUMAN_SEAT_DECKCHAIR { get { return "PROP_HUMAN_SEAT_DECKCHAIR"; } }
+        public static string PROP_HUMAN_SEAT_DECKCHAIR_DRINK { get { return "PROP_HUMAN_SEAT_DECKCHAIR_DRINK"; } }
+        public static string PROP_HUMAN_SEAT_MUSCLE_BENCH_PRESS { get { return "PROP_HUMAN_SEAT_MUSCLE_BENCH_PRESS"; } }
+        public static string PROP_HUMAN_SEAT_MUSCLE_BENCH_PRESS_PRISON { get { return "PROP_HUMAN_SEAT_MUSCLE_BENCH_PRESS_PRISON"; } }
+        public static string PROP_HUMAN_SEAT_SEWING { get { return "PROP_HUMAN_SEAT_SEWING"; } }
+        public static string PROP_HUMAN_SEAT_STRIP_WATCH { get { return "PROP_HUMAN_SEAT_STRIP_WATCH"; } }
+        public static string PROP_HUMAN_SEAT_SUNLOUNGER { get { return "PROP_HUMAN_SEAT_SUNLOUNGER"; } }
+        public static string PROP_HUMAN_STAND_IMPATIENT { get { return "PROP_HUMAN_STAND_IMPATIENT"; } }
+        public static string CODE_HUMAN_COWER { get { return "CODE_HUMAN_COWER"; } }
+        public static string CODE_HUMAN_CROSS_ROAD_WAIT { get { return "CODE_HUMAN_CROSS_ROAD_WAIT"; } }
+        public static string CODE_HUMAN_PARK_CAR { get { return "CODE_HUMAN_PARK_CAR"; } }
+        public static string PROP_HUMAN_MOVIE_BULB { get { return "PROP_HUMAN_MOVIE_BULB"; } }
+        public static string PROP_HUMAN_MOVIE_STUDIO_LIGHT { get { return "PROP_HUMAN_MOVIE_STUDIO_LIGHT"; } }
+        public static string CODE_HUMAN_MEDIC_KNEEL { get { return "CODE_HUMAN_MEDIC_KNEEL"; } }
+        public static string CODE_HUMAN_MEDIC_TEND_TO_DEAD { get { return "CODE_HUMAN_MEDIC_TEND_TO_DEAD"; } }
+        public static string CODE_HUMAN_MEDIC_TIME_OF_DEATH { get { return "CODE_HUMAN_MEDIC_TIME_OF_DEATH"; } }
+        public static string CODE_HUMAN_POLICE_CROWD_CONTROL { get { return "CODE_HUMAN_POLICE_CROWD_CONTROL"; } }
+        public static string CODE_HUMAN_POLICE_INVESTIGATE { get { return "CODE_HUMAN_POLICE_INVESTIGATE"; } }
+        public static string CODE_HUMAN_STAND_COWER { get { return "CODE_HUMAN_STAND_COWER"; } }
+        public static string EAR_TO_TEXT { get { return "EAR_TO_TEXT"; } }
+        public static string EAR_TO_TEXT_FAT { get { return "EAR_TO_TEXT_FAT"; } }
+#pragma warning restore 1591
+        public static void StartScenarioIfNone(this Ped ped, string scenarioName)
+        {
+            if (!ped.HasScenario())
+            {
+                ped.StartScenario(scenarioName);
+            }
+        }
+
+        public static void StartScenario(this Ped ped, string scenarioName)
+        {
+            NativeFunction.Natives.TASK_START_SCENARIO_IN_PLACE(ped, scenarioName, 0, true);
+        }
+
+        public static bool HasScenario(this Ped ped)
+        {
+            return NativeFunction.Natives.PED_HAS_USE_SCENARIO_TASK<bool>(ped);
+        }
+    }
+}

--- a/ComputerPlus/Function.cs
+++ b/ComputerPlus/Function.cs
@@ -49,7 +49,7 @@ namespace ComputerPlus
         }
         private static RectangleF taskbar = new RectangleF();
         private static Color taskbar_col = Color.FromArgb(160, 0, 0, 0);
-        private static int width, height;
+        // private static int width, height;
         private static string update_text = "";
 
         /// <summary>
@@ -374,7 +374,12 @@ namespace ComputerPlus
         {
             MakeSpaceForNewRecent();
             string name = Functions.GetPersonaForPed(ped).FullName;
-            EntryPoint.recent_text.Add(String.Format("Looked up person: {0}", name));
+            EntryPoint.AddRecentText(String.Format("Looked up person: {0}", name));
+            if (ped != null && !ped.IsPersistent)
+            {
+                ped.IsPersistent = true;
+                Globals.persistedRageEntities.Add(ped);
+            }
         }
 
         /// <summary>
@@ -385,7 +390,12 @@ namespace ComputerPlus
         {
             MakeSpaceForNewRecent();
             string lp = veh.LicensePlate;
-            EntryPoint.recent_text.Add(String.Format("Looked up vehicle: {0} ({1})", lp, GetVehicleDisplayName(veh)));
+            EntryPoint.AddRecentText(String.Format("Looked up vehicle: {0} ({1})", lp, GetVehicleDisplayName(veh)));
+            if (veh != null && !veh.IsPersistent)
+            {
+                veh.IsPersistent = true;
+                Globals.persistedRageEntities.Add(veh);
+            }
         }
 
         /// <summary>
@@ -396,7 +406,7 @@ namespace ComputerPlus
         internal static void AddBackupRequestToRecents(string response, string unit)
         {
             MakeSpaceForNewRecent();
-            EntryPoint.recent_text.Add(String.Format("Requested backup: {0} ({1})", unit, response));
+            EntryPoint.AddRecentText(String.Format("Requested backup: {0} ({1})", unit, response));
         }
 
         /// <summary>

--- a/ComputerPlus/Globals.cs
+++ b/ComputerPlus/Globals.cs
@@ -8,6 +8,7 @@ using ComputerPlus.Controllers;
 using ComputerPlus.Interfaces.Reports.Models;
 using ComputerPlus.DB;
 using Gwen;
+using Rage;
 
 namespace ComputerPlus
 {
@@ -49,15 +50,16 @@ namespace ComputerPlus
         private static String Clipboard = String.Empty;
         internal static readonly String DefaultAssetPath = @"Plugins\LSPDFR\ComputerPlus\";
         internal static Storage Store;
-        internal static readonly Version SchemaVersion = new Version("1.0.1");
+        internal static readonly Version SchemaVersion = new Version("1.0.2");
         internal static bool? BlockInputNeeded;
+        internal static List<Rage.Entity> persistedRageEntities = new List<Rage.Entity>();
 
         internal static Styles Style = new Styles();
 
-        internal async static Task OpenStore()
+        internal static void OpenStore()
         {
             if (Store == null)
-                Store = await Storage.ReadOrInit();
+                Store = Storage.ReadOrInit();
         }
 
         static public ArrestReport PendingArrestReport
@@ -87,6 +89,12 @@ namespace ComputerPlus
         } = null;
 
         public static VehicleDefinitions VehicleDefinitions
+        {
+            get;
+            internal set;
+        } = null;
+
+        public static List<String> WantedReasons
         {
             get;
             internal set;

--- a/ComputerPlus/Globals.cs
+++ b/ComputerPlus/Globals.cs
@@ -100,6 +100,12 @@ namespace ComputerPlus
             internal set;
         } = null;
 
+        public static List<CitationDefinition> CitationList
+        {
+            get;
+            internal set;
+        } = null;
+
 
         internal static bool HasTrafficTicketsInHand()
         {

--- a/ComputerPlus/Interfaces/ComputerMain/ComputerMain.cs
+++ b/ComputerPlus/Interfaces/ComputerMain/ComputerMain.cs
@@ -7,16 +7,13 @@ using Gwen.Control;
 using System;
 using ComputerPlus.Interfaces.ComputerPedDB;
 using ComputerPlus.Interfaces.ComputerVehDB;
-using ComputerPlus.Extensions.Gwen;
 using ComputerPlus.Controllers;
-using ComputerPlus.Extensions.Gwen;
-using ComputerPlus.Interfaces.Common;
 
 namespace ComputerPlus
 {
     internal class ComputerMain : GwenForm
     {
-        private Button btn_logout, btn_ped_db, btn_veh_db, btn_request, btn_activecalls, btn_notepad, btn_arrest_report, btn_browse_report;
+        private Button btn_logout, btn_ped_db, btn_veh_db, btn_request, btn_activecalls, btn_notepad, btn_citation_history, btn_arrest_history;
         internal ListBox list_recent;
         private Label label_external_ui;
         private ComboBox list_external_ui;
@@ -43,9 +40,13 @@ namespace ComputerPlus
             this.btn_ped_db.Clicked -= this.PedDBButtonClickedHandler;
             this.btn_veh_db.Clicked -= this.VehDBButtonClickedHandler;
             this.btn_request.Clicked -= this.RequestBackupButtonClickedHandler;
+            this.btn_notepad.Clicked -= OpenNotepadHandler;
+            this.btn_citation_history.Clicked -= this.ReportsClickedHandler;
+            this.btn_arrest_history.Clicked -= this.ReportsClickedHandler;
             this.cb_toggle_background.CheckChanged -= checkbox_change;
             this.cb_toggle_pause.CheckChanged -= checkbox_change;
             this.btn_activecalls.Clicked -= this.ActiveCallsClickedHandler;
+            EntryPoint.OnRecentTextAdded -= RecentTextChangedHandler;
             if (ShouldShowExtraUIControls)
             {
                 list_external_ui.ItemSelected -= ExternalUISelected;
@@ -63,13 +64,10 @@ namespace ComputerPlus
             this.btn_veh_db.Clicked += this.VehDBButtonClickedHandler;
             this.btn_request.Clicked += this.RequestBackupButtonClickedHandler;
             this.btn_notepad.Clicked += OpenNotepadHandler;
-            //this.btn_arrest_report.Clicked += this.ReportsClickedHandler;
-            //this.btn_browse_report.Clicked += this.ReportsClickedHandler;
+            this.btn_citation_history.Clicked += this.ReportsClickedHandler;
+            this.btn_arrest_history.Clicked += this.ReportsClickedHandler;
 
-            this.btn_browse_report.Disable();
-            this.btn_browse_report.Hide();
-            this.btn_arrest_report.Disable();
-            this.btn_arrest_report.Hide();
+            EntryPoint.OnRecentTextAdded += RecentTextChangedHandler;
 
             this.cb_toggle_background.CheckChanged += checkbox_change;
             this.cb_toggle_pause.CheckChanged += checkbox_change;
@@ -86,10 +84,7 @@ namespace ComputerPlus
             });
             this.btn_activecalls.Clicked += this.ActiveCallsClickedHandler;
             this.Window.DisableResizing();
-            foreach (string r in EntryPoint.recent_text)
-            {
-                list_recent.AddRow(r);
-            }
+            RecentTextChangedHandler();
             this.Position = new Point(Game.Resolution.Width / 2 - this.Window.Width / 2, Game.Resolution.Height / 2 - this.Window.Height / 2);
 
             if (ShouldShowExtraUIControls)
@@ -99,7 +94,6 @@ namespace ComputerPlus
                 Globals.SortedExternalUI.ToList().ForEach(x => list_external_ui.AddItem(x.DisplayName, x.Identifier.ToString()));
                 list_external_ui.ItemSelected += ExternalUISelected;
             }
-
         }
 
         private void OpenNotepadHandler(Base sender, ClickedEventArgs arguments)
@@ -127,10 +121,10 @@ namespace ComputerPlus
             //else if(sender == btn_arrest_report)
             //ComputerReportsController.ShowTrafficCitationCreate(null);
 
-            if (sender == btn_browse_report)
+            if (sender == btn_arrest_history)
                 ComputerReportsController.ShowArrestReportList();
-            else if (sender == btn_arrest_report)
-                ComputerReportsController.ShowArrestReportCreate(null, null);
+            else if (sender == btn_citation_history)
+                ComputerReportsController.ShowTrafficCitationList();
         }
 
 
@@ -147,6 +141,15 @@ namespace ComputerPlus
         private void RequestBackupButtonClickedHandler(Base sender, ClickedEventArgs e)
         {
             OpenRequestBackupForm();
+        }
+
+        private void RecentTextChangedHandler()
+        {
+            list_recent.Clear();
+            foreach (string r in EntryPoint.recent_text.Reverse<String>())
+            {
+                list_recent.AddRow(r);
+            }
         }
 
 

--- a/ComputerPlus/Interfaces/ComputerMain/ComputerMainTemplate.Designer.cs
+++ b/ComputerPlus/Interfaces/ComputerMain/ComputerMainTemplate.Designer.cs
@@ -42,48 +42,54 @@
             this.list_external_ui = new System.Windows.Forms.ComboBox();
             this.cb_toggle_pause = new System.Windows.Forms.CheckBox();
             this.cb_toggle_background = new System.Windows.Forms.CheckBox();
-            this.btn_arrest_report = new System.Windows.Forms.Button();
+            this.btn_citation_history = new System.Windows.Forms.Button();
             this.btn_notepad = new System.Windows.Forms.Button();
-            this.btn_browse_report = new System.Windows.Forms.Button();
+            this.btn_arrest_history = new System.Windows.Forms.Button();
             this.SuspendLayout();
             // 
             // btn_ped_db
             // 
             this.btn_ped_db.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.btn_ped_db.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
-            this.btn_ped_db.Location = new System.Drawing.Point(64, 198);
+            this.btn_ped_db.BackColor = System.Drawing.Color.Transparent;
+            this.btn_ped_db.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
+            this.btn_ped_db.ForeColor = System.Drawing.Color.RoyalBlue;
+            this.btn_ped_db.Location = new System.Drawing.Point(142, 176);
             this.btn_ped_db.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.btn_ped_db.Name = "btn_ped_db";
-            this.btn_ped_db.Size = new System.Drawing.Size(125, 30);
+            this.btn_ped_db.Size = new System.Drawing.Size(120, 30);
             this.btn_ped_db.TabIndex = 0;
             this.btn_ped_db.Text = "Ped Database";
-            this.btn_ped_db.UseVisualStyleBackColor = true;
+            this.btn_ped_db.UseVisualStyleBackColor = false;
             this.btn_ped_db.Click += new System.EventHandler(this.button1_Click);
             // 
             // btn_veh_db
             // 
             this.btn_veh_db.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.btn_veh_db.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
-            this.btn_veh_db.Location = new System.Drawing.Point(193, 198);
+            this.btn_veh_db.BackColor = System.Drawing.Color.Transparent;
+            this.btn_veh_db.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
+            this.btn_veh_db.ForeColor = System.Drawing.Color.RoyalBlue;
+            this.btn_veh_db.Location = new System.Drawing.Point(266, 176);
             this.btn_veh_db.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.btn_veh_db.Name = "btn_veh_db";
-            this.btn_veh_db.Size = new System.Drawing.Size(125, 30);
+            this.btn_veh_db.Size = new System.Drawing.Size(120, 30);
             this.btn_veh_db.TabIndex = 1;
             this.btn_veh_db.Text = "Vehicle Database";
-            this.btn_veh_db.UseVisualStyleBackColor = true;
+            this.btn_veh_db.UseVisualStyleBackColor = false;
             this.btn_veh_db.Click += new System.EventHandler(this.button2_Click);
             // 
             // btn_logout
             // 
             this.btn_logout.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.btn_logout.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
-            this.btn_logout.Location = new System.Drawing.Point(258, 234);
+            this.btn_logout.BackColor = System.Drawing.Color.Transparent;
+            this.btn_logout.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
+            this.btn_logout.ForeColor = System.Drawing.Color.Red;
+            this.btn_logout.Location = new System.Drawing.Point(514, 213);
             this.btn_logout.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.btn_logout.Name = "btn_logout";
-            this.btn_logout.Size = new System.Drawing.Size(125, 30);
+            this.btn_logout.Size = new System.Drawing.Size(120, 30);
             this.btn_logout.TabIndex = 2;
             this.btn_logout.Text = " Logout ";
-            this.btn_logout.UseVisualStyleBackColor = true;
+            this.btn_logout.UseVisualStyleBackColor = false;
             this.btn_logout.Click += new System.EventHandler(this.button3_Click);
             // 
             // list_recent
@@ -95,21 +101,23 @@
             this.list_recent.Location = new System.Drawing.Point(15, 32);
             this.list_recent.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.list_recent.Name = "list_recent";
-            this.list_recent.Size = new System.Drawing.Size(619, 121);
+            this.list_recent.Size = new System.Drawing.Size(619, 134);
             this.list_recent.TabIndex = 3;
             this.list_recent.SelectedIndexChanged += new System.EventHandler(this.list_recent_SelectedIndexChanged);
             // 
             // btn_request
             // 
             this.btn_request.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.btn_request.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
-            this.btn_request.Location = new System.Drawing.Point(322, 198);
+            this.btn_request.BackColor = System.Drawing.Color.Transparent;
+            this.btn_request.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
+            this.btn_request.ForeColor = System.Drawing.Color.SeaGreen;
+            this.btn_request.Location = new System.Drawing.Point(390, 176);
             this.btn_request.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.btn_request.Name = "btn_request";
-            this.btn_request.Size = new System.Drawing.Size(125, 30);
+            this.btn_request.Size = new System.Drawing.Size(120, 30);
             this.btn_request.TabIndex = 4;
             this.btn_request.Text = "Request Backup";
-            this.btn_request.UseVisualStyleBackColor = true;
+            this.btn_request.UseVisualStyleBackColor = false;
             this.btn_request.Click += new System.EventHandler(this.btn_request_Click);
             // 
             // label1
@@ -124,19 +132,21 @@
             // btn_activecalls
             // 
             this.btn_activecalls.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.btn_activecalls.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
-            this.btn_activecalls.Location = new System.Drawing.Point(451, 198);
+            this.btn_activecalls.BackColor = System.Drawing.Color.Transparent;
+            this.btn_activecalls.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
+            this.btn_activecalls.ForeColor = System.Drawing.Color.Sienna;
+            this.btn_activecalls.Location = new System.Drawing.Point(514, 176);
             this.btn_activecalls.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.btn_activecalls.Name = "btn_activecalls";
-            this.btn_activecalls.Size = new System.Drawing.Size(125, 30);
+            this.btn_activecalls.Size = new System.Drawing.Size(120, 30);
             this.btn_activecalls.TabIndex = 6;
             this.btn_activecalls.Text = "Call Details";
-            this.btn_activecalls.UseVisualStyleBackColor = true;
+            this.btn_activecalls.UseVisualStyleBackColor = false;
             // 
             // label_external_ui
             // 
             this.label_external_ui.AutoSize = true;
-            this.label_external_ui.Location = new System.Drawing.Point(79, 164);
+            this.label_external_ui.Location = new System.Drawing.Point(202, 8);
             this.label_external_ui.Name = "label_external_ui";
             this.label_external_ui.Size = new System.Drawing.Size(36, 13);
             this.label_external_ui.TabIndex = 7;
@@ -146,7 +156,7 @@
             // list_external_ui
             // 
             this.list_external_ui.FormattingEnabled = true;
-            this.list_external_ui.Location = new System.Drawing.Point(149, 161);
+            this.list_external_ui.Location = new System.Drawing.Point(244, 5);
             this.list_external_ui.Name = "list_external_ui";
             this.list_external_ui.Size = new System.Drawing.Size(312, 21);
             this.list_external_ui.TabIndex = 8;
@@ -154,69 +164,74 @@
             // 
             // cb_toggle_pause
             // 
-            this.cb_toggle_pause.AutoSize = true;
-            this.cb_toggle_pause.Location = new System.Drawing.Point(520, 232);
+            this.cb_toggle_pause.Location = new System.Drawing.Point(15, 206);
             this.cb_toggle_pause.Name = "cb_toggle_pause";
-            this.cb_toggle_pause.Size = new System.Drawing.Size(92, 17);
+            this.cb_toggle_pause.Size = new System.Drawing.Size(120, 17);
             this.cb_toggle_pause.TabIndex = 9;
             this.cb_toggle_pause.Text = "Toggle Pause";
             this.cb_toggle_pause.UseVisualStyleBackColor = true;
+            this.cb_toggle_pause.CheckedChanged += new System.EventHandler(this.cb_toggle_pause_CheckedChanged);
             // 
             // cb_toggle_background
             // 
-            this.cb_toggle_background.AutoSize = true;
-            this.cb_toggle_background.Location = new System.Drawing.Point(520, 255);
+            this.cb_toggle_background.Location = new System.Drawing.Point(15, 229);
             this.cb_toggle_background.Name = "cb_toggle_background";
             this.cb_toggle_background.Size = new System.Drawing.Size(120, 17);
             this.cb_toggle_background.TabIndex = 10;
             this.cb_toggle_background.Text = "Toggle Background";
             this.cb_toggle_background.UseVisualStyleBackColor = true;
             // 
-            // btn_arrest_report
+            // btn_citation_history
             // 
-            this.btn_arrest_report.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.btn_arrest_report.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
-            this.btn_arrest_report.Location = new System.Drawing.Point(118, 234);
-            this.btn_arrest_report.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
-            this.btn_arrest_report.Name = "btn_arrest_report";
-            this.btn_arrest_report.Size = new System.Drawing.Size(125, 30);
-            this.btn_arrest_report.TabIndex = 11;
-            this.btn_arrest_report.Text = "Report";
-            this.btn_arrest_report.UseVisualStyleBackColor = true;
+            this.btn_citation_history.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.btn_citation_history.BackColor = System.Drawing.Color.Transparent;
+            this.btn_citation_history.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
+            this.btn_citation_history.ForeColor = System.Drawing.Color.Indigo;
+            this.btn_citation_history.Location = new System.Drawing.Point(187, 213);
+            this.btn_citation_history.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            this.btn_citation_history.Name = "btn_citation_history";
+            this.btn_citation_history.Size = new System.Drawing.Size(161, 30);
+            this.btn_citation_history.TabIndex = 11;
+            this.btn_citation_history.Text = "Traffic Citation History";
+            this.btn_citation_history.UseVisualStyleBackColor = false;
             // 
             // btn_notepad
             // 
             this.btn_notepad.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+            this.btn_notepad.BackColor = System.Drawing.Color.Transparent;
             this.btn_notepad.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
-            this.btn_notepad.Location = new System.Drawing.Point(451, 5);
+            this.btn_notepad.ForeColor = System.Drawing.Color.Teal;
+            this.btn_notepad.Location = new System.Drawing.Point(576, 4);
             this.btn_notepad.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
             this.btn_notepad.Name = "btn_notepad";
             this.btn_notepad.Size = new System.Drawing.Size(59, 22);
             this.btn_notepad.TabIndex = 11;
             this.btn_notepad.Text = "Notepad";
-            this.btn_notepad.UseVisualStyleBackColor = true;
+            this.btn_notepad.UseVisualStyleBackColor = false;
             // 
-            // btn_browse_report
+            // btn_arrest_history
             // 
-            this.btn_browse_report.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.btn_browse_report.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
-            this.btn_browse_report.Location = new System.Drawing.Point(390, 234);
-            this.btn_browse_report.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
-            this.btn_browse_report.Name = "btn_browse_report";
-            this.btn_browse_report.Size = new System.Drawing.Size(125, 30);
-            this.btn_browse_report.TabIndex = 12;
-            this.btn_browse_report.Text = "Browse Report";
-            this.btn_browse_report.UseVisualStyleBackColor = true;
+            this.btn_arrest_history.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.btn_arrest_history.BackColor = System.Drawing.Color.Transparent;
+            this.btn_arrest_history.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
+            this.btn_arrest_history.ForeColor = System.Drawing.Color.Indigo;
+            this.btn_arrest_history.Location = new System.Drawing.Point(352, 213);
+            this.btn_arrest_history.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
+            this.btn_arrest_history.Name = "btn_arrest_history";
+            this.btn_arrest_history.Size = new System.Drawing.Size(158, 30);
+            this.btn_arrest_history.TabIndex = 12;
+            this.btn_arrest_history.Text = "Arrest Report History";
+            this.btn_arrest_history.UseVisualStyleBackColor = false;
             // 
             // ComputerMainTemplate
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.BackColor = System.Drawing.SystemColors.Control;
-            this.ClientSize = new System.Drawing.Size(645, 274);
-            this.Controls.Add(this.btn_browse_report);
+            this.ClientSize = new System.Drawing.Size(645, 256);
+            this.Controls.Add(this.btn_arrest_history);
             this.Controls.Add(this.btn_notepad);
-            this.Controls.Add(this.btn_arrest_report);
+            this.Controls.Add(this.btn_citation_history);
             this.Controls.Add(this.cb_toggle_background);
             this.Controls.Add(this.cb_toggle_pause);
             this.Controls.Add(this.list_external_ui);
@@ -224,10 +239,10 @@
             this.Controls.Add(this.btn_activecalls);
             this.Controls.Add(this.label1);
             this.Controls.Add(this.btn_request);
-            this.Controls.Add(this.list_recent);
             this.Controls.Add(this.btn_logout);
             this.Controls.Add(this.btn_veh_db);
             this.Controls.Add(this.btn_ped_db);
+            this.Controls.Add(this.list_recent);
             this.Font = new System.Drawing.Font("Microsoft Sans Serif", 11F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel, ((byte)(0)));
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.FixedSingle;
             this.Margin = new System.Windows.Forms.Padding(2, 3, 2, 3);
@@ -256,7 +271,7 @@
         private CheckBox cb_toggle_pause;
         private CheckBox cb_toggle_background;
         private Button btn_notepad;
-        private Button btn_arrest_report;
-        private Button btn_browse_report;
+        private Button btn_citation_history;
+        private Button btn_arrest_history;
     }
 }

--- a/ComputerPlus/Interfaces/ComputerMain/ComputerMainTemplate.cs
+++ b/ComputerPlus/Interfaces/ComputerMain/ComputerMainTemplate.cs
@@ -46,5 +46,10 @@ namespace ComputerPlus
         {
 
         }
+
+        private void cb_toggle_pause_CheckedChanged(object sender, EventArgs e)
+        {
+
+        }
     }
 }

--- a/ComputerPlus/Interfaces/ComputerPedDB/ComputerPedSearch.cs
+++ b/ComputerPlus/Interfaces/ComputerPedDB/ComputerPedSearch.cs
@@ -57,7 +57,8 @@ namespace ComputerPlus.Interfaces.ComputerPedDB
                 {
                     text_manual_name.Error("The ped no longer exists");
                 }
-                else {
+                else
+                {
                     text_manual_name.ClearError();
                     list_manual_results.AddPed(ped);
                     ComputerPedController.LastSelected = ped;

--- a/ComputerPlus/Interfaces/ComputerPedDB/ComputerPedSearch.cs
+++ b/ComputerPlus/Interfaces/ComputerPedDB/ComputerPedSearch.cs
@@ -8,6 +8,7 @@ using Rage;
 using LSPD_First_Response.Engine.Scripting.Entities;
 using ComputerPlus.Extensions.Gwen;
 using ComputerPlus.Controllers.Models;
+using System.Runtime.ExceptionServices;
 
 namespace ComputerPlus.Interfaces.ComputerPedDB
 {
@@ -74,9 +75,8 @@ namespace ComputerPlus.Interfaces.ComputerPedDB
             try
             {
                 ComputerPedController controller = ComputerPedController.Instance;
-                list_collected_ids.Clear();
-                var results = controller.GetRecentSearches()
-                .Where(x => x.Validate()).ToList();
+                list_manual_results.Clear();
+                var results = controller.GetRecentSearches().Where(x => x.Validate()).ToList();
                 //@TODO choose if we want to remove null items from the list -- may cause user confusion
                 if (results != null && results.Count > 0)
                 {
@@ -98,7 +98,7 @@ namespace ComputerPlus.Interfaces.ComputerPedDB
                 list_collected_ids.Clear();
                 foreach(var persona in peds.Select(x => controller.LookupPersona(x)))
                 {
-                    list_collected_ids.AddPed(persona);
+                    if (persona != null) list_collected_ids.AddPed(persona);
                 }
             }
             catch (Exception e)
@@ -113,6 +113,7 @@ namespace ComputerPlus.Interfaces.ComputerPedDB
             list_manual_results.UnselectAll();
         }
 
+        [HandleProcessCorruptedStateExceptions]
         private void onListItemSelected(Base sender, ItemSelectedEventArgs arguments)
         {
             try
@@ -121,6 +122,7 @@ namespace ComputerPlus.Interfaces.ComputerPedDB
                 {                
                     ComputerPedController.LastSelected = arguments.SelectedItem.UserData as ComputerPlusEntity;                
                     ComputerPedController.ActivatePedView();
+                    Function.AddPedToRecents(ComputerPedController.LastSelected.Ped);
                     ClearSelections();
                 }
                 else

--- a/ComputerPlus/Interfaces/ComputerPedDB/ComputerPedView.cs
+++ b/ComputerPlus/Interfaces/ComputerPedDB/ComputerPedView.cs
@@ -44,7 +44,9 @@ namespace ComputerPlus.Interfaces.ComputerPedDB
 
         StateControlledTextbox text_first_name, text_last_name,
                text_home_address, text_dob, text_license_status,
-               text_wanted_status, text_times_stopped, text_age;
+               text_wanted_status_false, text_times_stopped, text_age;
+
+        StateControlledMultilineTextbox text_wanted_status_true;
 
         Label lbl_alert, lbl_first_name, lbl_last_name,
                lbl_home_address, lbl_dob, lbl_license_status,
@@ -104,7 +106,8 @@ namespace ComputerPlus.Interfaces.ComputerPedDB
             
 
             lbl_wanted_status = new Label(this) { Text = "Wanted Status" };
-            text_wanted_status = new StateControlledTextbox(this) { IsDisabled = true };
+            text_wanted_status_true = new StateControlledMultilineTextbox(this) { IsDisabled = true, IsHidden = true };
+            text_wanted_status_false = new StateControlledTextbox(this) { IsDisabled = true, IsHidden = true };
 
             lbl_times_stopped = new Label(this) { Text = "Times Stopped" };
             text_times_stopped = new StateControlledTextbox(this) { IsDisabled = true };
@@ -113,8 +116,6 @@ namespace ComputerPlus.Interfaces.ComputerPedDB
             ped_image_holder.ImageName = Function.DetermineImagePath(Entity.Ped);
             ped_image_holder.ShouldCacheToTexture = true;
 
-
-           
         }
 
         protected override void Layout(GwenSkin.Base skin)
@@ -142,14 +143,19 @@ namespace ComputerPlus.Interfaces.ComputerPedDB
             text_dob.SetPosition(text_age.X, text_home_address.Y);
             lbl_dob.SetPosition(text_dob.X, lbl_home_address.Y);
             Gwen.Align.PlaceDownLeft(lbl_license_status, text_home_address, Configs.BaseFormControlSpacingTriple);
-            text_license_status.SmallSize();
+            text_license_status.SetSize(150, 21);
             Gwen.Align.PlaceRightBottom(text_license_status, lbl_license_status, Configs.BaseFormControlSpacing);
-            Gwen.Align.PlaceDownLeft(lbl_wanted_status, lbl_license_status, Configs.BaseFormControlSpacing);
-            text_wanted_status.SmallSize();
-            Gwen.Align.PlaceRightBottom(text_wanted_status, lbl_wanted_status, Configs.BaseFormControlSpacing);
-            Gwen.Align.PlaceDownLeft(lbl_times_stopped, lbl_wanted_status, Configs.BaseFormControlSpacing);
+            Gwen.Align.PlaceDownLeft(lbl_times_stopped, lbl_license_status, Configs.BaseFormControlSpacing);
             text_times_stopped.SmallSize();
-            text_times_stopped.SetPosition(text_wanted_status.X, lbl_times_stopped.Y);
+            Gwen.Align.PlaceRightBottom(text_times_stopped, lbl_times_stopped, Configs.BaseFormControlSpacing);
+
+            Gwen.Align.PlaceDownLeft(lbl_wanted_status, lbl_times_stopped, Configs.BaseFormControlSpacing);
+            text_wanted_status_false.SmallSize();
+
+            Gwen.Align.PlaceRightBottom(text_wanted_status_false, lbl_wanted_status, Configs.BaseFormControlSpacing);
+            text_wanted_status_true.SetSize(332, 90);
+            text_wanted_status_true.SetPosition(text_times_stopped.X, lbl_wanted_status.Y);
+
             ped_image_holder.RegularSizeVertical();
             ped_image_holder.SetPosition(text_age.Right + Configs.BaseFormControlSpacingDouble, text_age.Y + Configs.BaseFormControlSpacingDouble);
 
@@ -166,10 +172,13 @@ namespace ComputerPlus.Interfaces.ComputerPedDB
                 }
                 else
                 {
-                    text_license_status.Warn(Entity.LicenseStateString);
+                    string licenseStateString = Entity.LicenseStateString;
+                    if (licenseStateString.Equals("Expired"))
+                        text_license_status.Warn(String.Format(@"Expired ({0} days)", Entity.Ped.GetDrivingLicenseExpirationDuration()));
+                    else
+                        text_license_status.Warn(licenseStateString);
                 }
                 
-
                 if (Entity.IsAgent)
                 {
                     lbl_alert.SetText("Federal agent");
@@ -185,8 +194,20 @@ namespace ComputerPlus.Interfaces.ComputerPedDB
                 text_home_address.Text = Entity.Ped.GetHomeAddress();
                 text_dob.Text = Entity.DOBString;
                 //text_dob.SetToolTipText("MM/dd/yyyy");
-                if (Entity.IsWanted) text_wanted_status.Warn("Wanted");
-                else text_wanted_status.SetText("None");
+
+                if (Entity.IsWanted)
+                {
+                    text_wanted_status_true.IsHidden = false;
+                    text_wanted_status_false.IsHidden = true;
+                    text_wanted_status_true.Warn("Wanted for " + Entity.WantedReason);
+                }
+                else
+                {
+                    text_wanted_status_true.IsHidden = true;
+                    text_wanted_status_false.IsHidden = false;
+                    text_wanted_status_false.SetText("None");
+                }
+
                 text_times_stopped.Text = Entity.TimesStopped.ToString();
             }
         }

--- a/ComputerPlus/Interfaces/ComputerVehDB/ComputerVehicleDetails.cs
+++ b/ComputerPlus/Interfaces/ComputerVehDB/ComputerVehicleDetails.cs
@@ -81,6 +81,8 @@ namespace ComputerPlus.Interfaces.ComputerVehDB
 
         public void InitializeLayout()
         {
+            Function.Log("inside ComputerVehicleDetails.InitializeLayout()");
+
             labelFont = this.Skin.DefaultFont.Copy();
             labelFont.Size = 14;
             labelFont.Smooth = true;
@@ -109,7 +111,6 @@ namespace ComputerPlus.Interfaces.ComputerVehDB
 
             labeled_alpr = new LabeledComponent<Label>(registrationContent, "ALPR", new Label(registrationContent), RelationalPosition.LEFT, RelationalSize.MEDIUM, Configs.BaseFormControlSpacingDouble, labelFont, System.Drawing.Color.Red);
             labeled_owner_alert = new LabeledComponent<Label>(registrationContent, "Alert", new Label(registrationContent),  RelationalPosition.LEFT, RelationalSize.MEDIUM, Configs.BaseFormControlSpacingDouble, labelFont, System.Drawing.Color.Red);
-
 
             ownerInformation = new FormSection(this, "Owner Information");
             ownerContent = new Base(this);
@@ -395,44 +396,47 @@ namespace ComputerPlus.Interfaces.ComputerVehDB
             cb_action.AddItem("Blip (30 sec)", "Blip", QuickActions.BLIP_VEHICLE);
             cb_action.AddItem("Create Traffic Citation", "TrafficCitation", QuickActions.CREATE_TRAFFIC_CITATION);
             cb_action.AddItem("Create Arrest Report", "ArrestReport", QuickActions.CREATE_ARREST_REPORT_FOR_DRIVER);
-
-
+            
             labeled_age.Component.Text = DetailedEntity.Entity.AgeString;
             labeled_first_name.Component.Text = DetailedEntity.Entity.FirstName;
             labeled_last_name.Component.Text = DetailedEntity.Entity.LastName;
             labeled_home_address.Component.Text = Owner.GetHomeAddress();
             labeled_dob.Component.Text = DetailedEntity.Entity.DOBString;
-            if (DetailedEntity.Entity.IsWanted) labeled_wanted_status.Component.Warn("Wanted");
-            else labeled_wanted_status.Component.SetText("None");
+            if (DetailedEntity.Entity.IsWanted)
+                labeled_wanted_status.Component.Warn("Wanted");
+            else
+                labeled_wanted_status.Component.SetText("None");
             labeled_times_stopped.Component.Text = DetailedEntity.Entity.TimesStopped.ToString();
 
             labeled_vehicle_model.Component.Text = Vehicle.Model.Name;
             labeled_vehicle_license.Component.Text = Vehicle.LicensePlate;
             if (ComputerPlusEntity.PersonaType == PersonaTypes.BPS)
             {
-                Function.LogDebug(String.Format("Null check is {0} is type {1}", DetailedEntity.Entity.RawPedPersona == null, DetailedEntity.Entity.RawPedPersona is British_Policing_Script.BritishPersona));
-                var driverPersona = (British_Policing_Script.BritishPersona)DetailedEntity.Entity.RawPedPersona;
-                var vehiclePersona = (British_Policing_Script.VehicleRecords)DetailedEntity.Entity.RawVehiclePersona;
-                Function.LogDebug("Got vehicle persona");
-                Function.LogDebug(String.Format("vehiclePersona null {0}| labeled_vehicle_registration_status null {1} | labeled_vehicle_registration_status.Component null {2}", vehiclePersona == null, labeled_vehicle_registration_status, labeled_vehicle_registration_status.Component));
-                if (vehiclePersona.IsTaxed) labeled_vehicle_registration_status.Component.SetText("No");
-                else labeled_vehicle_registration_status.Component.Warn("Yes");
+                if (BritishPolicingFunctions.IsVehicleRegistered(DetailedEntity.Entity.RawVehiclePersona))
+                    labeled_vehicle_registration_status.Component.SetText("No");
+                else
+                    labeled_vehicle_registration_status.Component.Warn("Yes");
                 Function.LogDebug("set labeled_vehicle_registration_status");
 
-
-                if (vehiclePersona.Insured) labeled_vehicle_insurance_status.Component.SetText("Yes");
-                else labeled_vehicle_insurance_status.Component.Warn("No");
+                if (BritishPolicingFunctions.IsVehicleInsured(DetailedEntity.Entity.RawVehiclePersona))
+                    labeled_vehicle_insurance_status.Component.SetText("Yes");
+                else
+                    labeled_vehicle_insurance_status.Component.Warn("No");
                 Function.LogDebug("set labeled_vehicle_insurance_status");
 
-                if (vehiclePersona.HasMOT) labeled_vehicle_extra_1.Component.SetText("Yes");
-                else labeled_vehicle_extra_1.Component.Warn("No");
+                if (BritishPolicingFunctions.DoesVehicleHaveMOT(DetailedEntity.Entity.RawVehiclePersona))
+                    labeled_vehicle_extra_1.Component.SetText("Yes");
+                else
+                    labeled_vehicle_extra_1.Component.Warn("No");
                 Function.LogDebug("set labeled_vehicle_extra_1");
 
-                if (vehiclePersona.HasSORN) labeled_vehicle_extra_2.Component.SetText("Yes");
-                else labeled_vehicle_extra_2.Component.Warn("No");
+                if (BritishPolicingFunctions.DoesVehicleHaveSORN(DetailedEntity.Entity.RawVehiclePersona))
+                    labeled_vehicle_extra_2.Component.SetText("Yes");
+                else
+                    labeled_vehicle_extra_2.Component.Warn("No");
                 Function.LogDebug("set labeled_vehicle_extra_2");
 
-                if (driverPersona.IsInsuredToDriveVehicle(vehiclePersona))
+                if (BritishPolicingFunctions.IsPedInsuredToDriveVehicle(DetailedEntity.Entity.RawPedPersona, DetailedEntity.Entity.RawVehiclePersona))
                     labeled_ped_extra_1.Component.SetText("Yes");
                 else
                     labeled_ped_extra_1.Component.Warn("No");
@@ -446,7 +450,8 @@ namespace ComputerPlus.Interfaces.ComputerVehDB
 
                 if (TrafficPolicerFunction.GetVehicleRegistrationStatus(Vehicle) == EVehicleStatus.Valid) labeled_vehicle_registration_status.Component.SetText("Valid");
                 else labeled_vehicle_registration_status.Component.Warn("Expired");
-            } else
+            }
+            else
             {
                 labeled_vehicle_insurance_status.Hide();
                 labeled_vehicle_registration_status.Hide();

--- a/ComputerPlus/Interfaces/ComputerVehDB/ComputerVehicleSearch.cs
+++ b/ComputerPlus/Interfaces/ComputerVehDB/ComputerVehicleSearch.cs
@@ -8,6 +8,7 @@ using Rage;
 using LSPD_First_Response.Engine.Scripting.Entities;
 using ComputerPlus.Controllers.Models;
 using ComputerPlus.Extensions.Gwen;
+using System.Runtime.ExceptionServices;
 
 namespace ComputerPlus.Interfaces.ComputerVehDB
 {
@@ -83,6 +84,7 @@ namespace ComputerPlus.Interfaces.ComputerVehDB
             this.Close();
         }
 
+        [HandleProcessCorruptedStateExceptions]
         private void onListItemSelected(Base sender, ItemSelectedEventArgs arguments)
         {
             try
@@ -90,6 +92,7 @@ namespace ComputerPlus.Interfaces.ComputerVehDB
                 if (arguments.SelectedItem.UserData is ComputerPlusEntity)
                 {
                     ComputerVehicleController.LastSelected = arguments.SelectedItem.UserData as ComputerPlusEntity;
+                    Function.AddVehicleToRecents(ComputerVehicleController.LastSelected.Vehicle);
                     ClearSelections();
                     this.ShowDetailsView();
                 }
@@ -98,7 +101,7 @@ namespace ComputerPlus.Interfaces.ComputerVehDB
             {
                 Function.Log(e.ToString());
             }
-}
+        }
         
 
         private void PopulateAnprList()

--- a/ComputerPlus/Interfaces/ComputerVehDB/ComputerVehicleViewExtended.cs
+++ b/ComputerPlus/Interfaces/ComputerVehDB/ComputerVehicleViewExtended.cs
@@ -46,6 +46,8 @@ namespace ComputerPlus.Interfaces.ComputerVehDB
 
         internal void InitializeLayout()
         {
+            Function.Log("inside ComputerVehicleViewExtended.InitializeLayout()");
+
             VehicleDetails = new ComputerVehicleDetails(this, DetailedEntity, VehicleViewQuickActionSelected);
             VehicleDetails.Dock = Pos.Fill;
             tabcontrol_details = new TabControl(this);
@@ -89,8 +91,6 @@ namespace ComputerPlus.Interfaces.ComputerVehDB
             this.SetSize(width, height);
             OnPageTabChanged(this, page);
         }
-
-      
 
         private void AddArrestReportsTab()
         {
@@ -149,7 +149,6 @@ namespace ComputerPlus.Interfaces.ComputerVehDB
                         var page = tabcontrol_details.AddPage("Traffic Citations", trafficCitationContainer);
                         page.UserData = Page.PED_TRAFFIC_CITATIONS;
                         page.Clicked += PageTabClicked;
-
                     }
                     else
                     {

--- a/ComputerPlus/Interfaces/Reports/Arrest/ArrestReportContainer.cs
+++ b/ComputerPlus/Interfaces/Reports/Arrest/ArrestReportContainer.cs
@@ -71,24 +71,28 @@ namespace ComputerPlus.Interfaces.Reports.Arrest
             arrestDetails.ChangeReport(Report);
         }
 
-        private async void SaveClicked(Base sender, ClickedEventArgs arguments)
+        private void SaveClicked(Base sender, ClickedEventArgs arguments)
         {
-            var result = await SaveReport();
+            var result = SaveReport();
             if (result == ArrestReportSaveResult.SAVE_ERROR)
             {
                 var message = (Report.Charges.Count == 0) ? "Report has no charges" : "The Report is missing required information";
                 new MessageBox(this, message);
             }
+            else
+            {
+                this.Window.Close();
+            }
         }
 
-        private async Task<ArrestReportSaveResult> SaveReport()
+        private ArrestReportSaveResult SaveReport()
         {
             try
             {
                 Dictionary<String, String> validationErrors;
                 if (Report.Validate(out validationErrors))
                 {
-                    await ComputerReportsController.SaveArrestRecordAsync(Report);
+                    ComputerReportsController.SaveArrestRecordAsync(Report);
                     if (Report == Globals.PendingArrestReport)
                     {
                         Globals.PendingArrestReport = new ArrestReport();
@@ -143,8 +147,8 @@ namespace ComputerPlus.Interfaces.Reports.Arrest
                 {
                     btn_clear.Clicked += ClearClicked;
                     btn_save.Clicked += SaveClicked;
-                    btn_clear.SetPosition(tabContainer.Right - btn_save.Width - 10, tabContainer.Y - 10);
-                    btn_save.SetPosition(tabContainer.Right - btn_clear.Width - btn_save.Width - 10 - 10, tabContainer.Y - 10);
+                    btn_clear.SetPosition(tabContainer.Right - btn_save.Width - btn_clear.Width - 10 - 10, tabContainer.Y - 10);
+                    btn_save.SetPosition(tabContainer.Right - btn_save.Width - 10, tabContainer.Y - 10);
                     tabContainer.Margin = new Margin(0, 20, 0, 0);
                 }
                 else
@@ -162,9 +166,9 @@ namespace ComputerPlus.Interfaces.Reports.Arrest
             }
         }
 
-        private async void ContainerTabButtonClicked(Base sender, ClickedEventArgs arguments)
+        private void ContainerTabButtonClicked(Base sender, ClickedEventArgs arguments)
         {
-            await SaveReport();
+            SaveReport();
         }
 
         private void ReportDetailsTextChanged(Base sender, EventArgs arguments)

--- a/ComputerPlus/Interfaces/Reports/Arrest/ArrestReportContainerTemplate.Designer.cs
+++ b/ComputerPlus/Interfaces/Reports/Arrest/ArrestReportContainerTemplate.Designer.cs
@@ -35,7 +35,7 @@
             // btn_clear
             // 
             this.btn_clear.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel);
-            this.btn_clear.Location = new System.Drawing.Point(630, 13);
+            this.btn_clear.Location = new System.Drawing.Point(525, 13);
             this.btn_clear.Name = "btn_clear";
             this.btn_clear.Size = new System.Drawing.Size(50, 23);
             this.btn_clear.TabIndex = 0;
@@ -45,11 +45,11 @@
             // btn_save
             // 
             this.btn_save.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Pixel);
-            this.btn_save.Location = new System.Drawing.Point(574, 12);
+            this.btn_save.Location = new System.Drawing.Point(581, 13);
             this.btn_save.Name = "btn_save";
-            this.btn_save.Size = new System.Drawing.Size(50, 23);
+            this.btn_save.Size = new System.Drawing.Size(114, 23);
             this.btn_save.TabIndex = 1;
-            this.btn_save.Text = "Save";
+            this.btn_save.Text = "Save and Close";
             this.btn_save.UseVisualStyleBackColor = true;
             // 
             // ArrestReportContainerTemplate

--- a/ComputerPlus/Interfaces/Reports/Arrest/ArrestReportList.cs
+++ b/ComputerPlus/Interfaces/Reports/Arrest/ArrestReportList.cs
@@ -132,13 +132,13 @@ namespace ComputerPlus.Interfaces.Reports.Arrest
 
    
 
-        private async void OpenReport(ArrestReport report)
+        private void OpenReport(ArrestReport report)
         {
             if (report != null)
             {
                 if (OnArrestReportSelected == null)
                 {
-                    await ComputerReportsController.ShowArrestReportView(report);
+                    ComputerReportsController.ShowArrestReportView(report);
                 }
                 else
                 {

--- a/ComputerPlus/Interfaces/Reports/Arrest/ArrestReportView.cs
+++ b/ComputerPlus/Interfaces/Reports/Arrest/ArrestReportView.cs
@@ -150,7 +150,7 @@ namespace ComputerPlus.Interfaces.Reports.Arrest
             labeled_arrest_street_address.SetValueText(Report.ArrestStreetAddress);
             labeled_arrest_city.SetValueText(Report.ArrestCity);
             labeled_arrest_date.SetValueText(Function.ToLocalDateString(Report.ArrestDate, TextBoxExtensions.DateOutputPart.DATE, TextBoxExtensions.DateOutputPart.DATE));
-            labeled_arrest_time.SetValueText(Function.ToLocalDateString(Report.ArrestDate, TextBoxExtensions.DateOutputPart.TIME, TextBoxExtensions.DateOutputPart.TIME));
+            labeled_arrest_time.SetValueText(Function.ToLocalDateString(Report.ArrestTime, TextBoxExtensions.DateOutputPart.TIME, TextBoxExtensions.DateOutputPart.TIME));
             tb_report_details.SetValueText(Report.Details);
         }
 

--- a/ComputerPlus/Interfaces/Reports/Models/ArrestChargeLineItem.cs
+++ b/ComputerPlus/Interfaces/Reports/Models/ArrestChargeLineItem.cs
@@ -2,10 +2,7 @@
 using SQLite.Net.Attributes;
 using SQLiteNetExtensions.Attributes;
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+
 
 namespace ComputerPlus.Interfaces.Reports.Models
 {

--- a/ComputerPlus/Interfaces/Reports/Models/Charge.cs
+++ b/ComputerPlus/Interfaces/Reports/Models/Charge.cs
@@ -1,9 +1,6 @@
 ﻿using SQLite.Net.Attributes;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using System.Xml.Serialization;
 
 namespace ComputerPlus.Interfaces.Reports.Models

--- a/ComputerPlus/Interfaces/SimpleNotepad/KeyBinder.cs
+++ b/ComputerPlus/Interfaces/SimpleNotepad/KeyBinder.cs
@@ -1,0 +1,236 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Forms;
+using Rage;
+
+namespace ComputerPlus.Interfaces
+{
+    interface IKeyBinder
+    {
+        void AddMonitorKeyBinding(Keys key);
+        void AddMonitorControllerBinding(ControllerButtons button);
+        void StartEventMonitoring();
+        void StopEventMonitoring();
+    }
+    enum KeyBinderInput { Controller, Keyboard, Game };
+    internal class KeyBinder
+    {
+        internal readonly ControllerButtons ControllerButton;
+        internal readonly ControllerButtons ModifierControllerButton;
+        internal readonly Keys Key;
+        internal readonly Keys ModifierKey;
+        internal readonly GameControl GameControlArg;
+        readonly bool UseRageKeyPressBuffers;
+        internal KeyBinderInput Input
+        {
+            get
+            {
+                return GameControlArg != GameControl.InteractionMenu ? KeyBinderInput.Game :
+                    Key != Keys.None ? KeyBinderInput.Keyboard : KeyBinderInput.Controller;
+            }
+        }
+        internal bool HasModifier
+        {
+            get
+            {
+                var input = Input;
+                switch(input)
+                {
+                    case KeyBinderInput.Keyboard:
+                        return ModifierKey != Keys.None;
+                    case KeyBinderInput.Controller:
+                        return ModifierControllerButton != ControllerButtons.None;
+                    default: return false;
+                }
+             }
+        }
+
+        internal String FriendlyName
+        {
+            get
+            {
+                switch(Input)
+                {                    
+                    case KeyBinderInput.Game:
+                        return String.Format("~INPUT_{0}~", GameControlArg.ToString().ToUpper());
+                    case KeyBinderInput.Controller:
+                        return HasModifier ? String.Format("~r~~h~{0}~h~ ~s~+ ~r~~h~{1}~h~~s~", ModifierControllerButton.ToString(), ControllerButton.ToString()) : ControllerButton.ToString();
+                    case KeyBinderInput.Keyboard:
+                        return HasModifier ? String.Format("{0} + {1}", FriendlyKeys.GetFriendlyName(ModifierKey), FriendlyKeys.GetFriendlyName(Key)) : FriendlyKeys.GetFriendlyName(Key);
+                    default:
+                        return String.Empty;
+                }
+            }
+        }
+        
+        internal bool WasTriggeredOnce;
+        internal bool IsPressed
+        {
+            get
+            {
+                bool result;
+                bool hasModifier = HasModifier;
+                if (Input == KeyBinderInput.Game)
+                {
+                    result = UseRageKeyPressBuffers ? Game.IsControlPressed(0, GameControlArg) : Game.IsControlJustPressed(0, GameControlArg);
+                }
+                else if (UseRageKeyPressBuffers)
+                {
+                    if (hasModifier)
+                        result = Input == KeyBinderInput.Keyboard ? Game.IsKeyDownRightNow(ModifierKey) && Game.IsKeyDownRightNow(Key) : Game.IsControllerButtonDownRightNow(ModifierControllerButton) && Game.IsControllerButtonDownRightNow(ControllerButton);
+                    else
+                        result = Input == KeyBinderInput.Keyboard ? Game.IsKeyDownRightNow(Key) : Game.IsControllerButtonDownRightNow(ControllerButton);
+                }
+                else
+                {
+                    if (hasModifier)
+                        result = Input == KeyBinderInput.Keyboard ? Game.IsKeyDownRightNow(ModifierKey) && Game.IsKeyDownRightNow(Key) : Game.IsControllerButtonDownRightNow(ModifierControllerButton) && Game.IsControllerButtonDownRightNow(ControllerButton);
+                    else
+                        result = Input == KeyBinderInput.Keyboard ? Game.IsKeyDownRightNow(Key) : Game.IsControllerButtonDownRightNow(ControllerButton);
+                }
+                if (!WasTriggeredOnce && result) WasTriggeredOnce = true;
+                return result;
+            }
+        }
+        private KeyBinder(bool useRageKeyPressBuffers = true, GameControl gameControl = GameControl.InteractionMenu)
+        {
+            UseRageKeyPressBuffers = useRageKeyPressBuffers;
+            GameControlArg = gameControl;
+        }
+        internal KeyBinder(Keys key, Keys modifierKey = Keys.None, bool useRageKeyPressBuffers = true) : this(useRageKeyPressBuffers)
+        {
+            ControllerButton = ControllerButtons.None;
+            ModifierKey = modifierKey;
+            Key = key;
+        }
+        internal KeyBinder(ControllerButtons controllerButton, ControllerButtons modifierButton = ControllerButtons.None, bool useRageKeyPressBuffers = true) : this(useRageKeyPressBuffers)
+        {
+            Key = Keys.None;
+            ModifierControllerButton = modifierButton;
+            ControllerButton = controllerButton;
+        }
+        internal KeyBinder(GameControl control, bool useRageKeyPressBuffers = true) : this(useRageKeyPressBuffers, control)
+        {
+            Key = Keys.None;
+            ControllerButton = ControllerButtons.None;
+        }
+    }
+    class KeyBinderMonitor : IKeyBinder
+    {
+        bool FiberCanRun = true;
+        int? MaxEvents;
+        int EventsTriggered;
+        GameFiber KeyListenerFiber;
+        List<KeyBinder> BoundKeys;
+        OnInputPressed EventTriggeredCallback;
+        KeyBinderMonitor()
+        {
+            KeyListenerFiber = new GameFiber(CheckForBinderEvents);
+            BoundKeys = new List<KeyBinder>();
+        }
+
+        KeyBinderMonitor(List<KeyBinder> binders)
+        {
+            BoundKeys = binders;
+        }
+
+        KeyBinderMonitor(List<KeyBinder> binders, OnInputPressed callback, int? maxEvents) : this(binders)
+        {
+            EventTriggeredCallback = callback;
+            this.MaxEvents = maxEvents;
+        }
+
+        ~KeyBinderMonitor()
+        {
+            StopEventMonitoring();
+        }
+        void CheckForBinderEvents()
+        {
+            while (FiberCanRun)
+            {
+                if (EventTriggeredCallback != null && BoundKeys.Any(x => x.IsPressed))
+                {
+                    if (MaxEvents.HasValue)
+                        EventsTriggered += 1;
+                    EventTriggeredCallback();
+                }
+                GameFiber.Yield();
+                if (MaxEvents.HasValue && MaxEvents.Value <= EventsTriggered)
+                    GameFiber.Hibernate();
+            }
+
+        }
+        public void StopEventMonitoring()
+        {
+            if (KeyListenerFiber == null) return;
+            try
+            {
+                KeyListenerFiber.Abort();
+            }
+            catch
+            {
+                KeyListenerFiber = null;
+            }
+        }
+        public void StartEventMonitoring()
+        {
+            if (FiberCanRun)
+            {
+                if (KeyListenerFiber.IsHibernating) KeyListenerFiber.Wake();
+                else KeyListenerFiber.Start();
+            }
+            else if (KeyListenerFiber != null)
+            {
+                StopEventMonitoring();   
+            }
+        }
+
+        public void AddMonitorBoundKey(KeyBinder binder)
+        {
+            BoundKeys.Add(binder);
+        }
+
+        public void AddMonitorKeyBinding(Keys key)
+        {
+            AddMonitorKeyBinding(key, Keys.None);
+        }
+
+        public void AddMonitorControllerBinding(ControllerButtons button)
+        {
+            AddMonitorControllerBinding(button, ControllerButtons.None);
+        }
+
+        public void AddMonitorKeyBinding(Keys key, Keys modifier = Keys.None)
+        {
+            BoundKeys.Add(new KeyBinder(key, modifier));
+        }
+
+        public void AddMonitorControllerBinding(ControllerButtons button, ControllerButtons modifier = ControllerButtons.None)
+        {
+            BoundKeys.Add(new KeyBinder(button, modifier));
+        }
+
+        internal static GameFiber MonitorForBinderListFactory(List<KeyBinder> binders, OnInputPressed callback, int? maxEvents)
+        {
+
+            var monitor = CreateNew(binders, callback, maxEvents);
+            return new GameFiber(monitor.StartEventMonitoring);
+        }
+
+        internal static KeyBinderMonitor CreateNew(List<KeyBinder> binders, OnInputPressed callback, int? maxEvents)
+        {
+            return new KeyBinderMonitor(binders, callback, maxEvents);
+        }
+
+        internal static KeyBinderMonitor CreateNew(KeyBinder binder, OnInputPressed callback, int? maxEvents)
+        {
+            return new KeyBinderMonitor(new List<KeyBinder>() { binder }, callback, maxEvents);
+        }
+    }
+    internal delegate void OnInputPressed();
+    internal delegate void StopRequested(object sender);
+   
+}

--- a/ComputerPlus/Resources/Schemas/1.0.2.sql
+++ b/ComputerPlus/Resources/Schemas/1.0.2.sql
@@ -1,0 +1,1 @@
+CREATE INDEX citation_ped on TrafficCitation (FirstName, LastName, DOB);

--- a/ComputerPlus/XmlConfigs.cs
+++ b/ComputerPlus/XmlConfigs.cs
@@ -131,6 +131,7 @@ namespace ComputerPlus
             Globals.CitationDefinitions = citationDefinitions;
             Globals.VehicleDefinitions = vehicleDefinitions;
             PopulateWarrantCharges(arrestChargeDefinitions);
+            PopulateCitationCategories(citationDefinitions);
         }
 
         private static void TransverseCharges(String parentName, Charge charge)
@@ -155,6 +156,29 @@ namespace ComputerPlus
             {
                 String categoryName = x.Name + ":\n";
                 x.Charges.ForEach(charge => TransverseCharges(categoryName, charge));
+            });
+        }
+
+
+        private static void TransverseCitations(CitationDefinition citation)
+        {
+            if (citation.IsContainer)
+            {
+                citation.Children.ForEach(childCitation => TransverseCitations(childCitation));
+            }
+            else
+            {
+                Globals.CitationList.Add(citation);
+            }
+        }
+
+        private static void PopulateCitationCategories(CitationCategories categories)
+        {
+            if (categories == null) return;
+            if (Globals.CitationList == null) Globals.CitationList = new List<CitationDefinition>();
+            categories.Categories.ForEach(x =>
+            {
+                x.Citations.ForEach(citation => TransverseCitations(citation));
             });
         }
 

--- a/ComputerPlus/XmlConfigs.cs
+++ b/ComputerPlus/XmlConfigs.cs
@@ -130,6 +130,32 @@ namespace ComputerPlus
             Globals.ChargeDefinitions = arrestChargeDefinitions;
             Globals.CitationDefinitions = citationDefinitions;
             Globals.VehicleDefinitions = vehicleDefinitions;
+            PopulateWarrantCharges(arrestChargeDefinitions);
+        }
+
+        private static void TransverseCharges(String parentName, Charge charge)
+        {
+            if (charge.IsContainer)
+            {
+                String chargeName = parentName + " => " + charge.Name + "\n";
+                charge.Children.ForEach(childCharge => TransverseCharges(chargeName, childCharge));
+            }
+            else
+            {
+                String chargeName = parentName + " => " + String.Format("{0}{1}", charge.Name, charge.IsFelony ? " (F)" : String.Empty);
+                Globals.WantedReasons.Add(chargeName);
+            }
+        }
+
+        private static void PopulateWarrantCharges(ChargeCategories categories)
+        {
+            if (categories == null) return;
+            if (Globals.WantedReasons == null) Globals.WantedReasons = new List<String>();
+            categories.Categories.ForEach(x =>
+            {
+                String categoryName = x.Name + ":\n";
+                x.Charges.ForEach(charge => TransverseCharges(categoryName, charge));
+            });
         }
 
 


### PR DESCRIPTION
List of improvements:
- previous arrest report & citation will be displayed when viewing ped/vehicle info (without crashing)
- reactivated traffic citation history
- reactivated arrest report history
- reactivated most recent action list on main window
- added wanted reason info when ped is wanted
- added proper db index for TrafficCitation table (bump the storage version to 1.0.2)
- made ped & vehicle persistent during C+ session to avoid crashes (they will be freed when Computer+ exit)
- saving newly created arrest report or citation will also close the window for better UX
- vehicle type will be showed correctly when viewing the citation history records
- fixed "give ticket" animation. now the ticket should disappear in the right time
- added driver license expiration days info (random)
- fixed incorrect time data source on arrest report view
- added various checking and handling to prevent potential crashes.

It's very stable on my machine, but still needs to be tested by other users, since i don't use alpr plugin and british policing plugin.

To test it, make sure to overwrite all C+ files/folders on your LSPDFR plugins folder. You may keep your old ".ini" file since there's no changes on that part.